### PR TITLE
23 uibe settings view

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.navigation.compose)
     implementation(libs.kotlinx.serialization.json)
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
     ksp(libs.androidx.room.compiler.v250)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.navigation.compose)
     implementation(libs.kotlinx.serialization.json)
-    implementation("androidx.datastore:datastore-preferences:1.1.1")
+    implementation(libs.androidx.datastore.preferences)
     ksp(libs.androidx.room.compiler.v250)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/example/conquest/MainActivity.kt
+++ b/app/src/main/java/com/example/conquest/MainActivity.kt
@@ -5,20 +5,32 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.ui.platform.LocalContext
 import com.example.conquest.components.Drawer
 import com.example.conquest.ui.theme.ConQuestTheme
+import androidx.compose.runtime.getValue
+import com.example.conquest.screens.rememberThemePreference
+
 
 class MainActivity : ComponentActivity() {
 
     @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         enableEdgeToEdge()
         setContent {
-            ConQuestTheme {
-                Scaffold() {
+            val context = LocalContext.current
+            val themePref by rememberThemePreference(context)
+            val darkTheme = when (themePref) {
+                "dark" -> true
+                "light" -> false
+                else -> isSystemInDarkTheme()
+            }
+
+            ConQuestTheme(darkTheme = darkTheme) {
+                Scaffold {
                     Drawer()
                 }
             }

--- a/app/src/main/java/com/example/conquest/components/Drawer.kt
+++ b/app/src/main/java/com/example/conquest/components/Drawer.kt
@@ -53,7 +53,7 @@ import kotlinx.coroutines.launch
 
 
 val routes = listOf(
-    MainScreen, SettingsScreenParams(name = null, age = 0)
+    MainScreen, SettingsScreenParams
 )
 
 val noDrawerRoutes = listOf(

--- a/app/src/main/java/com/example/conquest/components/Navigation.kt
+++ b/app/src/main/java/com/example/conquest/components/Navigation.kt
@@ -17,8 +17,8 @@ fun MainNavigation(navController: NavHostController, searchQuery: String) {
         composable<MainScreen> {
             MainScreen(navController, searchQuery)
         }
-        composable<SettingsScreenParams> { it ->
-            SettingsScreen(it)
+        composable<SettingsScreenParams> {
+            SettingsScreen()
         }
         composable<NewCosplayScreen> {
             NewCosplayScreen(navController)

--- a/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
@@ -23,7 +23,7 @@ fun MainCosplayScreen(navBackStackEntry: NavBackStackEntry) {
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
-    )  {
+    ) {
         Text(text = "Cosplay UID: ${args.uid}")
     }
 }

--- a/app/src/main/java/com/example/conquest/screens/MainScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/MainScreen.kt
@@ -19,6 +19,7 @@ import androidx.navigation.NavController
 import com.example.conquest.CosplayViewModel
 import kotlinx.serialization.Serializable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.font.FontWeight
 
@@ -45,10 +46,11 @@ fun MainScreen(navController: NavController, searchQuery: String) {
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .clip(RoundedCornerShape(32.dp))
                     .border(
                         width = 1.dp,
                         color = MaterialTheme.colorScheme.outline,
-                        shape = RoundedCornerShape(24.dp)
+                        shape = RoundedCornerShape(32.dp)
                     )
                     .clickable {
                         navController.navigate(MainCosplayScreen(cosplay.uid))

--- a/app/src/main/java/com/example/conquest/screens/NewCosplayScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/NewCosplayScreen.kt
@@ -186,7 +186,8 @@ fun NewCosplayScreen(
                             )
                         }
                     }
-                }, modifier = Modifier
+                },
+                modifier = Modifier
                     .weight(1f)
                     .height(40.dp),
                 colors = ButtonDefaults.buttonColors(

--- a/app/src/main/java/com/example/conquest/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/SettingsScreen.kt
@@ -40,8 +40,7 @@ object SettingsScreenParams
 @Composable
 fun SettingsScreen() {
     val context = LocalContext.current
-    val darkModeFlow = remember { getDarkModeOption(context) }
-    val selectedOption by darkModeFlow.collectAsState(initial = "automatic")
+    val selectedOption by rememberThemePreference(context)
     val coroutineScope = rememberCoroutineScope()
 
     val options = listOf("dark", "light", "automatic")

--- a/app/src/main/java/com/example/conquest/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/SettingsScreen.kt
@@ -1,30 +1,106 @@
 package com.example.conquest.screens
 
+import android.content.Context
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.navigation.NavBackStackEntry
-import androidx.navigation.toRoute
+import androidx.compose.ui.platform.LocalContext
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.serialization.Serializable
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.launch
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.unit.dp
 
 @Serializable
-data class SettingsScreenParams(
-    val name: String?,
-    val age: Int
-)
+object SettingsScreenParams
 
 @Composable
-fun SettingsScreen(it: NavBackStackEntry) {
-    val args = it.toRoute<SettingsScreenParams>()
+fun SettingsScreen() {
+    val context = LocalContext.current
+    val darkModeFlow = remember { getDarkMode(context) }
+    val darkMode by darkModeFlow.collectAsState(initial = false)
+    val coroutineScope = rememberCoroutineScope()
+
     Column(
         modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
+        verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally
-    )  {
-        Text(text = "${args.name}, ${args.age}")
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outline,
+                    shape = RoundedCornerShape(32.dp)
+                ),
+            shape = RoundedCornerShape(32.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 18.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = "Dark Mode",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+
+                Switch(
+                    checked = darkMode,
+                    onCheckedChange = { enabled ->
+                        coroutineScope.launch {
+                            setDarkMode(context, enabled)
+                        }
+                    },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = MaterialTheme.colorScheme.primary,
+                        checkedTrackColor = MaterialTheme.colorScheme.secondary,
+                        uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        uncheckedTrackColor = MaterialTheme.colorScheme.secondary
+                    )
+                )
+            }
+        }
     }
+}
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+
+val DARK_MODE_KEY = booleanPreferencesKey("dark_mode_enabled")
+
+suspend fun setDarkMode(context: Context, enabled: Boolean) {
+    context.dataStore.edit { prefs ->
+        prefs[DARK_MODE_KEY] = enabled
+    }
+}
+
+fun getDarkMode(context: Context): Flow<Boolean> = context.dataStore.data.map { prefs ->
+    prefs[DARK_MODE_KEY] == true
 }

--- a/app/src/main/java/com/example/conquest/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/conquest/ui/theme/Theme.kt
@@ -3,7 +3,6 @@ package com.example.conquest.ui.theme
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -57,7 +56,6 @@ private val HighContrastScheme = darkColorScheme(
 @Composable
 fun ConQuestTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
     dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
@@ -66,24 +64,14 @@ fun ConQuestTheme(
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
-
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
     }
-
-    val typographyScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-
-        darkTheme -> TypographyDark
-        else -> TypographyWhite
-    }
+    val typographyScheme = if (darkTheme) TypographyDark else TypographyWhite
 
     MaterialTheme(
         colorScheme = colorScheme,
-        typography = typographyScheme as Typography,
+        typography = typographyScheme,
         content = content
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.10.1"
+datastorePreferences = "1.1.7"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"
@@ -17,6 +18,7 @@ serialization = "1.6.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-room-compiler-v250 = { module = "androidx.room:room-compiler", version.ref = "roomCompiler" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }


### PR DESCRIPTION
This pull request introduces a theme preference system to the app, allowing users to select between "dark," "light," and "automatic" themes. It also includes updates to the UI, navigation, and dependencies to support this feature. The most significant changes are grouped below by theme.

### Theme Preference System:

* Added a `SettingsScreen` with a dropdown menu for selecting the theme preference (dark, light, or automatic). The selection is stored using Jetpack DataStore and retrieved via a Flow. (`app/src/main/java/com/example/conquest/screens/SettingsScreen.kt`)
* Introduced a `rememberThemePreference` function to observe theme changes and applied the user's preference in `MainActivity`. (`app/src/main/java/com/example/conquest/MainActivity.kt`)
* Updated the `ConQuestTheme` function to simplify typography handling and ensure the selected theme is applied consistently. (`app/src/main/java/com/example/conquest/ui/theme/Theme.kt`)

### Navigation Updates:

* Simplified `SettingsScreenParams` to an `object` since no parameters are passed anymore. Updated navigation logic to reflect this change. (`app/src/main/java/com/example/conquest/components/Navigation.kt`, `app/src/main/java/com/example/conquest/screens/SettingsScreen.kt`) [[1]](diffhunk://#diff-848603d07e971c3604d6fb6efc8edc8bf7a1a4718b41d98505cc6a1e527e5398L20-R21) [[2]](diffhunk://#diff-eac84a6ada1a98c5d7d49362176e0fe6688682229819c07a23fd0d0a11b249d0R3-R121)
* Removed unused arguments in the `Drawer` component's navigation routes. (`app/src/main/java/com/example/conquest/components/Drawer.kt`)

### UI Enhancements:

* Adjusted the `MainScreen` card design by increasing the corner radius for a more modern look. (`app/src/main/java/com/example/conquest/screens/MainScreen.kt`)
* Fixed formatting issues in the `NewCosplayScreen` layout for better readability and maintainability. (`app/src/main/java/com/example/conquest/screens/NewCosplayScreen.kt`)

### Dependency Updates:

* Added Jetpack DataStore Preferences library to manage theme settings. Updated `gradle/libs.versions.toml` and `app/build.gradle.kts` to include the new dependency. (`gradle/libs.versions.toml`, `app/build.gradle.kts`) [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR3) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR21) [[3]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R59)