### PR TITLE
38 be add the rest of required field in cosplays database

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.coil.compose)
+    implementation (libs.androidx.material.icons.extended)
     ksp(libs.androidx.room.compiler.v250)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation(libs.navigation.compose)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.coil.compose)
     ksp(libs.androidx.room.compiler.v250)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,7 +42,6 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/src/main/java/com/example/conquest/Application.kt
+++ b/app/src/main/java/com/example/conquest/Application.kt
@@ -7,10 +7,7 @@ import com.example.conquest.data.database.CosplayDatabase
 class ConQuestApplication : Application() {
     val database: CosplayDatabase by lazy {
         Room.databaseBuilder(
-                applicationContext,
-                CosplayDatabase::class.java,
-                "cosplays_database"
-            ).fallbackToDestructiveMigration(true)
-        .build()
+            applicationContext, CosplayDatabase::class.java, "cosplays_database"
+        ).fallbackToDestructiveMigration(true).build()
     }
 }

--- a/app/src/main/java/com/example/conquest/CosplayViewModel.kt
+++ b/app/src/main/java/com/example/conquest/CosplayViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.conquest.data.entity.Cosplay
 import com.example.conquest.data.entity.CosplayElement
 import com.example.conquest.data.entity.CosplayPhoto
+import com.example.conquest.data.entity.CosplayTask
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -19,6 +20,7 @@ class CosplayViewModel(application: Application) : AndroidViewModel(application)
     internal val dao = (application as ConQuestApplication).database.cosplayDao()
     internal val photoDao = (application as ConQuestApplication).database.cosplayPhotoDao()
     internal val elementDao = (application as ConQuestApplication).database.cosplayElementDao()
+    internal val taskDao = (application as ConQuestApplication).database.cosplayTaskDao()
 
     val allCosplays =
         dao.getAllCosplays().stateIn(viewModelScope, SharingStarted.Lazily, emptyList<Cosplay>())
@@ -64,10 +66,9 @@ class CosplayViewModel(application: Application) : AndroidViewModel(application)
     private val _elementCosplayId = MutableStateFlow<Int?>(0)
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val elements: StateFlow<List<CosplayElement>> =
-        _elementCosplayId.filterNotNull()
-            .flatMapLatest { id -> elementDao.getElementsForCosplay(id) }
-            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+    val elements: StateFlow<List<CosplayElement>> = _elementCosplayId.filterNotNull()
+        .flatMapLatest { id -> elementDao.getElementsForCosplay(id) }
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
     fun setElementCosplayId(id: Int) {
         _elementCosplayId.value = id
@@ -76,7 +77,29 @@ class CosplayViewModel(application: Application) : AndroidViewModel(application)
     fun deleteElementsByIds(ids: Set<Int>) {
         viewModelScope.launch {
             elementDao.deleteElementsByIds(ids)
+        }
+    }
 
+    private val _taskCosplayId = MutableStateFlow<Int?>(0)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val tasks: StateFlow<List<CosplayTask>> =
+        _taskCosplayId.filterNotNull().flatMapLatest { id -> taskDao.getTasksForCosplay(id) }
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    fun setTaskCosplayId(id: Int) {
+        _taskCosplayId.value = id
+    }
+
+    fun insertTask(task: CosplayTask) {
+        viewModelScope.launch {
+            taskDao.insertTask(task)
+        }
+    }
+
+    fun deleteTasksByIds(ids: Set<Int>) {
+        viewModelScope.launch {
+            taskDao.deleteTasksByIds(ids)
         }
     }
 }

--- a/app/src/main/java/com/example/conquest/CosplayViewModel.kt
+++ b/app/src/main/java/com/example/conquest/CosplayViewModel.kt
@@ -29,9 +29,12 @@ class CosplayViewModel(application: Application) : AndroidViewModel(application)
         }
     }
 
-    fun deleteCosplaysByIds(ids: Set<Int>) {
+    fun deleteCosplaysByIds(cosplayIds: Set<Int>) {
         viewModelScope.launch {
-            dao.deleteCosplaysByIds(ids)
+            val photos = photoDao.getPhotosForCosplayOnce(cosplayIds)
+            photoDao.deletePhotos(photos)
+            photos.forEach { deleteFileByPath(it.path) }
+            dao.deleteCosplaysByIds(cosplayIds)
         }
     }
 
@@ -75,5 +78,14 @@ class CosplayViewModel(application: Application) : AndroidViewModel(application)
             elementDao.deleteElementsByIds(ids)
 
         }
+    }
+}
+
+fun deleteFileByPath(path: String) {
+    try {
+        val file = java.io.File(path)
+        if (file.exists()) file.delete()
+    } catch (e: Exception) {
+        e.printStackTrace()
     }
 }

--- a/app/src/main/java/com/example/conquest/CosplayViewModel.kt
+++ b/app/src/main/java/com/example/conquest/CosplayViewModel.kt
@@ -29,9 +29,9 @@ class CosplayViewModel(application: Application) : AndroidViewModel(application)
         }
     }
 
-    fun deleteCosplay(cosplay: Cosplay) {
+    fun deleteCosplaysByIds(ids: Set<Int>) {
         viewModelScope.launch {
-            dao.delete(cosplay)
+            dao.deleteCosplaysByIds(ids)
         }
     }
 
@@ -68,5 +68,12 @@ class CosplayViewModel(application: Application) : AndroidViewModel(application)
 
     fun setElementCosplayId(id: Int) {
         _elementCosplayId.value = id
+    }
+
+    fun deleteElementsByIds(ids: Set<Int>) {
+        viewModelScope.launch {
+            elementDao.deleteElementsByIds(ids)
+
+        }
     }
 }

--- a/app/src/main/java/com/example/conquest/CosplayViewModel.kt
+++ b/app/src/main/java/com/example/conquest/CosplayViewModel.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.SharingStarted
 import androidx.lifecycle.viewModelScope
 import com.example.conquest.data.entity.Cosplay
+import com.example.conquest.data.entity.CosplayElement
 import com.example.conquest.data.entity.CosplayPhoto
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,6 +18,7 @@ import kotlinx.coroutines.launch
 class CosplayViewModel(application: Application) : AndroidViewModel(application) {
     internal val dao = (application as ConQuestApplication).database.cosplayDao()
     internal val photoDao = (application as ConQuestApplication).database.cosplayPhotoDao()
+    internal val elementDao = (application as ConQuestApplication).database.cosplayElementDao()
 
     val allCosplays =
         dao.getAllCosplays().stateIn(viewModelScope, SharingStarted.Lazily, emptyList<Cosplay>())
@@ -34,11 +36,11 @@ class CosplayViewModel(application: Application) : AndroidViewModel(application)
     }
 
     private val _cosplayId = MutableStateFlow<Int?>(0)
+
     @OptIn(ExperimentalCoroutinesApi::class)
-    val photos: StateFlow<List<CosplayPhoto>> = _cosplayId
-        .filterNotNull()
-        .flatMapLatest { id -> photoDao.getPhotosForCosplay(id) }
-        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+    val photos: StateFlow<List<CosplayPhoto>> =
+        _cosplayId.filterNotNull().flatMapLatest { id -> photoDao.getPhotosForCosplay(id) }
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
     fun setCosplayId(id: Int) {
         _cosplayId.value = id
@@ -48,5 +50,23 @@ class CosplayViewModel(application: Application) : AndroidViewModel(application)
         viewModelScope.launch {
             photoDao.insertPhoto(CosplayPhoto(cosplayId = cosplayId, path = path))
         }
+    }
+
+    fun insertElement(element: CosplayElement) {
+        viewModelScope.launch {
+            elementDao.insertElement(element)
+        }
+    }
+
+    private val _elementCosplayId = MutableStateFlow<Int?>(0)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val elements: StateFlow<List<CosplayElement>> =
+        _elementCosplayId.filterNotNull()
+            .flatMapLatest { id -> elementDao.getElementsForCosplay(id) }
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    fun setElementCosplayId(id: Int) {
+        _elementCosplayId.value = id
     }
 }

--- a/app/src/main/java/com/example/conquest/CosplayViewModel.kt
+++ b/app/src/main/java/com/example/conquest/CosplayViewModel.kt
@@ -10,6 +10,7 @@ import com.example.conquest.data.entity.CosplayElement
 import com.example.conquest.data.entity.CosplayPhoto
 import com.example.conquest.data.entity.CosplayTask
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNotNull
@@ -100,6 +101,24 @@ class CosplayViewModel(application: Application) : AndroidViewModel(application)
     fun deleteTasksByIds(ids: Set<Int>) {
         viewModelScope.launch {
             taskDao.deleteTasksByIds(ids)
+        }
+    }
+
+    fun getElementById(id: Int): Flow<CosplayElement?> {
+        return elementDao.getElementById(id)
+    }
+
+    fun updateElement(
+        id: Int,
+        name: String,
+        cost: Double?,
+        ready: Boolean,
+        bought: Boolean,
+        photoPath: String,
+        notes: String
+    ) {
+        viewModelScope.launch {
+            elementDao.updateElement(id, name, cost, ready, bought, photoPath, notes)
         }
     }
 }

--- a/app/src/main/java/com/example/conquest/CosplayViewModel.kt
+++ b/app/src/main/java/com/example/conquest/CosplayViewModel.kt
@@ -109,16 +109,10 @@ class CosplayViewModel(application: Application) : AndroidViewModel(application)
     }
 
     fun updateElement(
-        id: Int,
-        name: String,
-        cost: Double?,
-        ready: Boolean,
-        bought: Boolean,
-        photoPath: String,
-        notes: String
+        cosplayElement: CosplayElement
     ) {
         viewModelScope.launch {
-            elementDao.updateElement(id, name, cost, ready, bought, photoPath, notes)
+            elementDao.updateElement(cosplayElement)
         }
     }
 }

--- a/app/src/main/java/com/example/conquest/components/Drawer.kt
+++ b/app/src/main/java/com/example/conquest/components/Drawer.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Add
@@ -16,6 +17,8 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -128,11 +131,6 @@ fun Drawer(
                                 modifier = Modifier.fillMaxWidth(),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
-                                MyIcon(
-                                    { navController.navigate(NewCosplayScreen) },
-                                    Icons.Default.Add,
-                                    "Add new cosplay"
-                                )
                                 SearchBar(
                                     value = searchQuery, onValueChange = { searchQuery = it })
                             }
@@ -151,7 +149,21 @@ fun Drawer(
                             MyIcon({}, Icons.Default.AccountCircle, "Sort by")
                             MyIcon({}, Icons.Default.KeyboardArrowDown, "Order by")
                         })
-                    }) { padding ->
+                    },
+                    floatingActionButton = {
+                        FloatingActionButton(
+                            onClick = {
+                                navController.navigate(NewCosplayScreen)
+                            },
+                            containerColor = MaterialTheme.colorScheme.tertiary,
+                            contentColor = MaterialTheme.colorScheme.primary,
+                            shape = CircleShape
+                        ) {
+                            Icon(Icons.Default.Add, contentDescription = "Add new cosplay")
+                        }
+                    },
+                    floatingActionButtonPosition = FabPosition.Center
+                ) { padding ->
                     Column(
                         modifier = Modifier
                             .fillMaxSize()

--- a/app/src/main/java/com/example/conquest/components/Drawer.kt
+++ b/app/src/main/java/com/example/conquest/components/Drawer.kt
@@ -9,16 +9,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FabPosition
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -50,7 +46,6 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.conquest.screens.MainScreen
-import com.example.conquest.screens.NewCosplayScreen
 import com.example.conquest.screens.SettingsScreenParams
 import kotlinx.coroutines.launch
 
@@ -149,21 +144,7 @@ fun Drawer(
                             MyIcon({}, Icons.Default.AccountCircle, "Sort by")
                             MyIcon({}, Icons.Default.KeyboardArrowDown, "Order by")
                         })
-                    },
-                    floatingActionButton = {
-                        FloatingActionButton(
-                            onClick = {
-                                navController.navigate(NewCosplayScreen)
-                            },
-                            containerColor = MaterialTheme.colorScheme.tertiary,
-                            contentColor = MaterialTheme.colorScheme.primary,
-                            shape = CircleShape
-                        ) {
-                            Icon(Icons.Default.Add, contentDescription = "Add new cosplay")
-                        }
-                    },
-                    floatingActionButtonPosition = FabPosition.Center
-                ) { padding ->
+                    }) { padding ->
                     Column(
                         modifier = Modifier
                             .fillMaxSize()

--- a/app/src/main/java/com/example/conquest/components/Drawer.kt
+++ b/app/src/main/java/com/example/conquest/components/Drawer.kt
@@ -87,8 +87,7 @@ fun Drawer(
                             text = "ConQuest",
                             style = MaterialTheme.typography.headlineSmall,
                             color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier
-                                .padding(horizontal = 24.dp, vertical = 8.dp)
+                            modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
                         )
                         HorizontalDivider(
                             thickness = 1.dp,
@@ -135,9 +134,7 @@ fun Drawer(
                                     "Add new cosplay"
                                 )
                                 SearchBar(
-                                    value = searchQuery,
-                                    onValueChange = { searchQuery = it }
-                                )
+                                    value = searchQuery, onValueChange = { searchQuery = it })
                             }
                         }, navigationIcon = {
                             IconButton(onClick = {
@@ -146,8 +143,7 @@ fun Drawer(
                                 }
                             }) {
                                 Icon(
-                                    imageVector = Icons.Default.Menu,
-                                    contentDescription = "Menu"
+                                    imageVector = Icons.Default.Menu, contentDescription = "Menu"
                                 )
                             }
                         }, actions = {
@@ -159,7 +155,7 @@ fun Drawer(
                     Column(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(padding) // Apply padding from the drawer
+                            .padding(padding)
                     ) {
                         HorizontalDivider(thickness = 1.dp)
                         MainNavigation(navController, searchQuery)

--- a/app/src/main/java/com/example/conquest/components/Drawer.kt
+++ b/app/src/main/java/com/example/conquest/components/Drawer.kt
@@ -122,29 +122,47 @@ fun Drawer(
                     containerColor = MaterialTheme.colorScheme.background,
                     contentColor = MaterialTheme.colorScheme.primary,
                     topBar = {
-                        TopAppBar(colors = topAppBarColorsObject(), title = {
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                SearchBar(
-                                    value = searchQuery, onValueChange = { searchQuery = it })
-                            }
-                        }, navigationIcon = {
-                            IconButton(onClick = {
-                                scope.launch {
-                                    drawerState.open()
+                        if (currentRoute == "com.example.conquest.screens.SettingsScreenParams") {
+                            TopAppBar(
+                                colors = topAppBarColorsObject(),
+                                title = { Text("Settings screen") },
+                                navigationIcon = {
+                                    IconButton(onClick = {
+                                        scope.launch { drawerState.open() }
+                                    }) {
+                                        Icon(
+                                            imageVector = Icons.Default.Menu,
+                                            contentDescription = "Menu"
+                                        )
+                                    }
+                                },
+                                actions = {} // No actions on settings screen
+                            )
+                        } else {
+                            TopAppBar(colors = topAppBarColorsObject(), title = {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    SearchBar(
+                                        value = searchQuery,
+                                        onValueChange = { searchQuery = it })
                                 }
-                            }) {
-                                Icon(
-                                    imageVector = Icons.Default.Menu, contentDescription = "Menu"
-                                )
-                            }
-                        }, actions = {
-                            MyIcon({}, Icons.Default.Search, "Filter")
-                            MyIcon({}, Icons.Default.AccountCircle, "Sort by")
-                            MyIcon({}, Icons.Default.KeyboardArrowDown, "Order by")
-                        })
+                            }, navigationIcon = {
+                                IconButton(onClick = {
+                                    scope.launch { drawerState.open() }
+                                }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Menu,
+                                        contentDescription = "Menu"
+                                    )
+                                }
+                            }, actions = {
+                                MyIcon({}, Icons.Default.Search, "Filter")
+                                MyIcon({}, Icons.Default.AccountCircle, "Sort by")
+                                MyIcon({}, Icons.Default.KeyboardArrowDown, "Order by")
+                            })
+                        }
                     }) { padding ->
                     Column(
                         modifier = Modifier

--- a/app/src/main/java/com/example/conquest/components/Drawer.kt
+++ b/app/src/main/java/com/example/conquest/components/Drawer.kt
@@ -56,7 +56,8 @@ val routes = listOf(
 
 val noDrawerRoutes = listOf(
     "com.example.conquest.screens.NewCosplayScreen",
-    "com.example.conquest.screens.NewCosplayElementScreen/{cosplayId}"
+    "com.example.conquest.screens.NewCosplayElementScreen/{cosplayId}",
+    "com.example.conquest.screens.NewCosplayTaskScreen/{cosplayId}"
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -145,8 +146,7 @@ fun Drawer(
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
                                     SearchBar(
-                                        value = searchQuery,
-                                        onValueChange = { searchQuery = it })
+                                        value = searchQuery, onValueChange = { searchQuery = it })
                                 }
                             }, navigationIcon = {
                                 IconButton(onClick = {

--- a/app/src/main/java/com/example/conquest/components/Drawer.kt
+++ b/app/src/main/java/com/example/conquest/components/Drawer.kt
@@ -55,7 +55,8 @@ val routes = listOf(
 )
 
 val noDrawerRoutes = listOf(
-    "com.example.conquest.screens.NewCosplayScreen"
+    "com.example.conquest.screens.NewCosplayScreen",
+    "com.example.conquest.screens.NewCosplayElementScreen/{cosplayId}"
 )
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/example/conquest/components/Drawer.kt
+++ b/app/src/main/java/com/example/conquest/components/Drawer.kt
@@ -1,6 +1,5 @@
 package com.example.conquest.components
 
-import MainNavigation
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/app/src/main/java/com/example/conquest/components/MyFloatingActionButton.kt
+++ b/app/src/main/java/com/example/conquest/components/MyFloatingActionButton.kt
@@ -1,0 +1,30 @@
+package com.example.conquest.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun MyFab(
+    onClick: () -> Unit, modifier: Modifier = Modifier
+) {
+    FloatingActionButton(
+        onClick = onClick,
+        containerColor = MaterialTheme.colorScheme.tertiary,
+        contentColor = MaterialTheme.colorScheme.primary,
+        shape = RoundedCornerShape(50),
+        modifier = modifier
+            .padding(bottom = 16.dp)
+            .statusBarsPadding()
+    ) {
+        Icon(Icons.Default.Add, contentDescription = "Add")
+    }
+}

--- a/app/src/main/java/com/example/conquest/components/MyFloatingActionButton.kt
+++ b/app/src/main/java/com/example/conquest/components/MyFloatingActionButton.kt
@@ -3,28 +3,32 @@ package com.example.conquest.components
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun MyFab(
-    onClick: () -> Unit, modifier: Modifier = Modifier
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    containerColor: Color,
+    contentColor: Color,
+    icon: ImageVector,
+    contentDescription: String
 ) {
     FloatingActionButton(
         onClick = onClick,
-        containerColor = MaterialTheme.colorScheme.tertiary,
-        contentColor = MaterialTheme.colorScheme.primary,
+        containerColor = containerColor,
+        contentColor = contentColor,
         shape = RoundedCornerShape(50),
         modifier = modifier
             .padding(bottom = 16.dp)
             .statusBarsPadding()
     ) {
-        Icon(Icons.Default.Add, contentDescription = "Add")
+        Icon(icon, contentDescription = contentDescription)
     }
 }

--- a/app/src/main/java/com/example/conquest/components/Navigation.kt
+++ b/app/src/main/java/com/example/conquest/components/Navigation.kt
@@ -8,6 +8,7 @@ import com.example.conquest.screens.MainScreen
 import com.example.conquest.screens.NewCosplayElementScreen
 import com.example.conquest.screens.SettingsScreen
 import com.example.conquest.screens.NewCosplayScreen
+import com.example.conquest.screens.NewCosplayTaskScreen
 import com.example.conquest.screens.SettingsScreenParams
 
 @Composable
@@ -31,6 +32,10 @@ fun MainNavigation(navController: NavHostController, searchQuery: String) {
         composable<NewCosplayElementScreen> { backStackEntry ->
             val args = backStackEntry.toRoute<NewCosplayElementScreen>()
             NewCosplayElementScreen(args.cosplayId, navController)
+        }
+        composable<NewCosplayTaskScreen> { backStackEntry ->
+            val args = backStackEntry.toRoute<NewCosplayTaskScreen>()
+            NewCosplayTaskScreen(args.cosplayId, navController)
         }
     }
 }

--- a/app/src/main/java/com/example/conquest/components/Navigation.kt
+++ b/app/src/main/java/com/example/conquest/components/Navigation.kt
@@ -2,8 +2,10 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.example.conquest.screens.MainCosplayScreen
 import com.example.conquest.screens.MainScreen
+import com.example.conquest.screens.NewCosplayElementScreen
 import com.example.conquest.screens.SettingsScreen
 import com.example.conquest.screens.NewCosplayScreen
 import com.example.conquest.screens.SettingsScreenParams
@@ -24,7 +26,11 @@ fun MainNavigation(navController: NavHostController, searchQuery: String) {
             NewCosplayScreen(navController)
         }
         composable<MainCosplayScreen> { backStackEntry ->
-            MainCosplayScreen(backStackEntry)
+            MainCosplayScreen(backStackEntry, navController)
+        }
+        composable<NewCosplayElementScreen> { backStackEntry ->
+            val args = backStackEntry.toRoute<NewCosplayElementScreen>()
+            NewCosplayElementScreen(args.cosplayId, navController)
         }
     }
 }

--- a/app/src/main/java/com/example/conquest/components/Navigation.kt
+++ b/app/src/main/java/com/example/conquest/components/Navigation.kt
@@ -1,3 +1,5 @@
+package com.example.conquest.components
+
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost

--- a/app/src/main/java/com/example/conquest/components/Navigation.kt
+++ b/app/src/main/java/com/example/conquest/components/Navigation.kt
@@ -10,6 +10,7 @@ import com.example.conquest.screens.SettingsScreen
 import com.example.conquest.screens.NewCosplayScreen
 import com.example.conquest.screens.NewCosplayTaskScreen
 import com.example.conquest.screens.SettingsScreenParams
+import com.example.conquest.screens.EditCosplayElementScreen
 
 @Composable
 fun MainNavigation(navController: NavHostController, searchQuery: String) {
@@ -36,6 +37,12 @@ fun MainNavigation(navController: NavHostController, searchQuery: String) {
         composable<NewCosplayTaskScreen> { backStackEntry ->
             val args = backStackEntry.toRoute<NewCosplayTaskScreen>()
             NewCosplayTaskScreen(args.cosplayId, navController)
+        }
+        composable<EditCosplayElementScreen> { backStackEntry ->
+            val args = backStackEntry.toRoute<EditCosplayElementScreen>()
+            EditCosplayElementScreen(
+                elementId = args.elementId, navController = navController
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/conquest/components/SearchBar.kt
+++ b/app/src/main/java/com/example/conquest/components/SearchBar.kt
@@ -6,7 +6,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 @Composable
 fun SearchBar(
@@ -15,10 +17,11 @@ fun SearchBar(
     TextField(
         value = value,
         onValueChange = onValueChange,
-        placeholder = { Text("Search") },
-        modifier = Modifier.padding(start = 16.dp, top = 4.dp, bottom = 4.dp, end = 16.dp),
-        shape = RoundedCornerShape(24.dp),
+        placeholder = { Text("Search", fontSize = 16.sp) },
+        modifier = Modifier.padding(start = 16.dp, top = 6.dp, bottom = 6.dp, end = 16.dp),
+        shape = RoundedCornerShape(32.dp),
         singleLine = true,
-        colors = topAppBarTextFieldColorsObject()
+        colors = topAppBarTextFieldColorsObject(),
+        textStyle = TextStyle(fontSize = 16.sp)
     )
 }

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayDao.kt
@@ -1,7 +1,6 @@
 package com.example.conquest.data.dao
 
 import androidx.room.Dao
-import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import com.example.conquest.data.entity.Cosplay
@@ -12,8 +11,8 @@ interface CosplayDao {
     @Insert
     suspend fun insertCosplay(cosplay: Cosplay): Long
 
-    @Delete
-    suspend fun delete(cosplay: Cosplay)
+    @Query("DELETE FROM cosplays WHERE uid IN (:ids)")
+    suspend fun deleteCosplaysByIds(ids: Set<Int>)
 
     @Query("SELECT * FROM cosplays")
     fun getAllCosplays(): Flow<List<Cosplay>>

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayDao.kt
@@ -5,7 +5,6 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import com.example.conquest.data.entity.Cosplay
-import com.example.conquest.data.entity.CosplayPhoto
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -18,13 +17,4 @@ interface CosplayDao {
 
     @Query("SELECT * FROM cosplays")
     fun getAllCosplays(): Flow<List<Cosplay>>
-}
-
-@Dao
-interface CosplayPhotoDao {
-    @Insert
-    suspend fun insertPhoto(photo: CosplayPhoto)
-
-    @Query("SELECT * FROM cosplay_photos WHERE cosplay_id = :cosplayId")
-    fun getPhotosForCosplay(cosplayId: Int): Flow<List<CosplayPhoto>>
 }

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import com.example.conquest.data.entity.Cosplay
+import com.example.conquest.data.entity.CosplayPhoto
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -17,4 +18,13 @@ interface CosplayDao {
 
     @Query("SELECT * FROM cosplays")
     fun getAllCosplays(): Flow<List<Cosplay>>
+}
+
+@Dao
+interface CosplayPhotoDao {
+    @Insert
+    suspend fun insertPhoto(photo: CosplayPhoto)
+
+    @Query("SELECT * FROM cosplay_photos WHERE cosplay_id = :cosplayId")
+    fun getPhotosForCosplay(cosplayId: Int): Flow<List<CosplayPhoto>>
 }

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayElementDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayElementDao.kt
@@ -1,0 +1,11 @@
+package com.example.conquest.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import com.example.conquest.data.entity.CosplayElement
+
+@Dao
+interface CosplayElementDao {
+    @Insert
+    suspend fun insertElement(element: CosplayElement)
+}

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayElementDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayElementDao.kt
@@ -1,11 +1,20 @@
 package com.example.conquest.data.dao
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
+import androidx.room.Query
 import com.example.conquest.data.entity.CosplayElement
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface CosplayElementDao {
     @Insert
-    suspend fun insertElement(element: CosplayElement)
+    suspend fun insertElement(element: CosplayElement): Long
+
+    @Delete
+    suspend fun deleteElement(element: CosplayElement)
+
+    @Query("SELECT * FROM cosplay_elements WHERE cosplay_id = :cosplayId")
+    fun getElementsForCosplay(cosplayId: Int): Flow<List<CosplayElement>>
 }

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayElementDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayElementDao.kt
@@ -1,7 +1,6 @@
 package com.example.conquest.data.dao
 
 import androidx.room.Dao
-import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import com.example.conquest.data.entity.CosplayElement
@@ -12,8 +11,8 @@ interface CosplayElementDao {
     @Insert
     suspend fun insertElement(element: CosplayElement): Long
 
-    @Delete
-    suspend fun deleteElement(element: CosplayElement)
+    @Query("DELETE FROM cosplay_elements WHERE id IN (:ids)")
+    suspend fun deleteElementsByIds(ids: Set<Int>)
 
     @Query("SELECT * FROM cosplay_elements WHERE cosplay_id = :cosplayId")
     fun getElementsForCosplay(cosplayId: Int): Flow<List<CosplayElement>>

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayElementDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayElementDao.kt
@@ -3,6 +3,7 @@ package com.example.conquest.data.dao
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Update
 import com.example.conquest.data.entity.CosplayElement
 import kotlinx.coroutines.flow.Flow
 
@@ -20,12 +21,6 @@ interface CosplayElementDao {
     @Query("SELECT * FROM cosplay_elements WHERE id = :id LIMIT 1")
     fun getElementById(id: Int): Flow<CosplayElement?>
 
-    @Query(
-        """
-        UPDATE cosplay_elements 
-        SET name = :name, cost = :cost, ready = :ready, bought = :bought, photo_path = :photoPath, notes = :notes
-        WHERE id = :id
-        """
-    )
-    suspend fun updateElement(id: Int, name: String, cost: Double?, ready: Boolean, bought: Boolean, photoPath: String, notes: String)
+    @Update
+    suspend fun updateElement(cosplayElement: CosplayElement)
 }

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayElementDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayElementDao.kt
@@ -16,4 +16,16 @@ interface CosplayElementDao {
 
     @Query("SELECT * FROM cosplay_elements WHERE cosplay_id = :cosplayId")
     fun getElementsForCosplay(cosplayId: Int): Flow<List<CosplayElement>>
+
+    @Query("SELECT * FROM cosplay_elements WHERE id = :id LIMIT 1")
+    fun getElementById(id: Int): Flow<CosplayElement?>
+
+    @Query(
+        """
+        UPDATE cosplay_elements 
+        SET name = :name, cost = :cost, ready = :ready, bought = :bought, photo_path = :photoPath, notes = :notes
+        WHERE id = :id
+        """
+    )
+    suspend fun updateElement(id: Int, name: String, cost: Double?, ready: Boolean, bought: Boolean, photoPath: String, notes: String)
 }

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayPhotoDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayPhotoDao.kt
@@ -1,6 +1,7 @@
 package com.example.conquest.data.dao
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import com.example.conquest.data.entity.CosplayPhoto
@@ -10,6 +11,12 @@ import kotlinx.coroutines.flow.Flow
 interface CosplayPhotoDao {
     @Insert
     suspend fun insertPhoto(photo: CosplayPhoto)
+
+    @Delete
+    suspend fun deletePhotos(photos: List<CosplayPhoto>)
+
+    @Query("SELECT * FROM cosplay_photos WHERE cosplay_id = :cosplaysId")
+    suspend fun getPhotosForCosplayOnce(cosplaysId: Set<Int>): List<CosplayPhoto>
 
     @Query("SELECT * FROM cosplay_photos WHERE cosplay_id = :cosplayId")
     fun getPhotosForCosplay(cosplayId: Int): Flow<List<CosplayPhoto>>

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayPhotoDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayPhotoDao.kt
@@ -1,0 +1,16 @@
+package com.example.conquest.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.example.conquest.data.entity.CosplayPhoto
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CosplayPhotoDao {
+    @Insert
+    suspend fun insertPhoto(photo: CosplayPhoto)
+
+    @Query("SELECT * FROM cosplay_photos WHERE cosplay_id = :cosplayId")
+    fun getPhotosForCosplay(cosplayId: Int): Flow<List<CosplayPhoto>>
+}

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayPhotoDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayPhotoDao.kt
@@ -15,7 +15,7 @@ interface CosplayPhotoDao {
     @Delete
     suspend fun deletePhotos(photos: List<CosplayPhoto>)
 
-    @Query("SELECT * FROM cosplay_photos WHERE cosplay_id = :cosplaysId")
+    @Query("SELECT * FROM cosplay_photos WHERE cosplay_id IN (:cosplaysId)")
     suspend fun getPhotosForCosplayOnce(cosplaysId: Set<Int>): List<CosplayPhoto>
 
     @Query("SELECT * FROM cosplay_photos WHERE cosplay_id = :cosplayId")

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayTaskDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayTaskDao.kt
@@ -2,10 +2,18 @@ package com.example.conquest.data.dao
 
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.Query
 import com.example.conquest.data.entity.CosplayTask
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface CosplayTaskDao {
     @Insert
-    suspend fun insertElement(task: CosplayTask)
+    suspend fun insertTask(task: CosplayTask)
+
+    @Query("DELETE FROM cosplay_tasks WHERE id IN (:ids)")
+    suspend fun deleteTasksByIds(ids: Set<Int>)
+
+    @Query("SELECT * FROM cosplay_tasks WHERE cosplay_id = :cosplayId")
+    fun getTasksForCosplay(cosplayId: Int): Flow<List<CosplayTask>>
 }

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayTaskDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayTaskDao.kt
@@ -1,0 +1,11 @@
+package com.example.conquest.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import com.example.conquest.data.entity.CosplayTask
+
+@Dao
+interface CosplayTaskDao {
+    @Insert
+    suspend fun insertElement(task: CosplayTask)
+}

--- a/app/src/main/java/com/example/conquest/data/database/CosplayDatabase.kt
+++ b/app/src/main/java/com/example/conquest/data/database/CosplayDatabase.kt
@@ -4,16 +4,23 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.example.conquest.data.dao.CosplayDao
+import com.example.conquest.data.dao.CosplayElementDao
 import com.example.conquest.data.dao.CosplayPhotoDao
+import com.example.conquest.data.dao.CosplayTaskDao
 import com.example.conquest.data.entity.Cosplay
+import com.example.conquest.data.entity.CosplayElement
 import com.example.conquest.data.entity.CosplayPhoto
+import com.example.conquest.data.entity.CosplayTask
 import com.example.conquest.data.entity.DateConverter
 
 @Database(
-    entities = [Cosplay::class, CosplayPhoto::class], version = 4
+    entities = [Cosplay::class, CosplayPhoto::class, CosplayElement::class, CosplayTask::class],
+    version = 5
 )
 @TypeConverters(DateConverter::class)
 abstract class CosplayDatabase : RoomDatabase() {
     abstract fun cosplayDao(): CosplayDao
     abstract fun cosplayPhotoDao(): CosplayPhotoDao
+    abstract fun cosplayElementDao(): CosplayElementDao
+    abstract fun cosplayTaskDao(): CosplayTaskDao
 }

--- a/app/src/main/java/com/example/conquest/data/database/CosplayDatabase.kt
+++ b/app/src/main/java/com/example/conquest/data/database/CosplayDatabase.kt
@@ -4,11 +4,16 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.example.conquest.data.dao.CosplayDao
+import com.example.conquest.data.dao.CosplayPhotoDao
 import com.example.conquest.data.entity.Cosplay
+import com.example.conquest.data.entity.CosplayPhoto
 import com.example.conquest.data.entity.DateConverter
 
-@Database(entities = [Cosplay::class], version = 3)
+@Database(
+    entities = [Cosplay::class, CosplayPhoto::class], version = 4
+)
 @TypeConverters(DateConverter::class)
 abstract class CosplayDatabase : RoomDatabase() {
     abstract fun cosplayDao(): CosplayDao
+    abstract fun cosplayPhotoDao(): CosplayPhotoDao
 }

--- a/app/src/main/java/com/example/conquest/data/entity/Cosplay.kt
+++ b/app/src/main/java/com/example/conquest/data/entity/Cosplay.kt
@@ -2,6 +2,8 @@ package com.example.conquest.data.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverter
 import java.util.Date
@@ -16,6 +18,20 @@ data class Cosplay(
     @ColumnInfo(name = "initial_date") val initialDate: Date,
     @ColumnInfo(name = "due_date") val dueDate: Date?,
     @ColumnInfo(name = "budget") val budget: Double?
+)
+
+@Entity(
+    tableName = "cosplay_photos", foreignKeys = [ForeignKey(
+        entity = Cosplay::class,
+        parentColumns = ["uid"],
+        childColumns = ["cosplay_id"],
+        onDelete = ForeignKey.CASCADE
+    )], indices = [Index(value = ["cosplay_id"])]
+)
+data class CosplayPhoto(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    @ColumnInfo(name = "cosplay_id") val cosplayId: Int,
+    @ColumnInfo(name = "path") val path: String
 )
 
 class DateConverter {

--- a/app/src/main/java/com/example/conquest/data/entity/CosplayElements.kt
+++ b/app/src/main/java/com/example/conquest/data/entity/CosplayElements.kt
@@ -1,0 +1,27 @@
+package com.example.conquest.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "cosplay_elements", foreignKeys = [ForeignKey(
+        entity = Cosplay::class,
+        parentColumns = ["uid"],
+        childColumns = ["cosplay_id"],
+        onDelete = ForeignKey.CASCADE
+    )], indices = [Index(value = ["cosplay_id"])]
+)
+data class CosplayElement(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    @ColumnInfo(name = "cosplay_id") val cosplayId: Int,
+    @ColumnInfo(name = "name") val name: String,
+    @ColumnInfo(name = "cost") val cost: Double?,
+    @ColumnInfo(name = "ready") val ready: Boolean,
+    @ColumnInfo(name = "photo_path") val photoPath: String?,
+    @ColumnInfo(name = "highlight") val highlight: Boolean = false,
+    @ColumnInfo(name = "bought") val bought: Boolean,
+    @ColumnInfo(name = "notes") val notes: String?
+)

--- a/app/src/main/java/com/example/conquest/data/entity/CosplayPhotos.kt
+++ b/app/src/main/java/com/example/conquest/data/entity/CosplayPhotos.kt
@@ -1,0 +1,21 @@
+package com.example.conquest.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "cosplay_photos", foreignKeys = [ForeignKey(
+        entity = Cosplay::class,
+        parentColumns = ["uid"],
+        childColumns = ["cosplay_id"],
+        onDelete = ForeignKey.CASCADE
+    )], indices = [Index(value = ["cosplay_id"])]
+)
+data class CosplayPhoto(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    @ColumnInfo(name = "cosplay_id") val cosplayId: Int,
+    @ColumnInfo(name = "path") val path: String
+)

--- a/app/src/main/java/com/example/conquest/data/entity/CosplayTasks.kt
+++ b/app/src/main/java/com/example/conquest/data/entity/CosplayTasks.kt
@@ -1,0 +1,24 @@
+package com.example.conquest.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "cosplay_tasks", foreignKeys = [ForeignKey(
+        entity = Cosplay::class,
+        parentColumns = ["uid"],
+        childColumns = ["cosplay_id"],
+        onDelete = ForeignKey.CASCADE
+    )], indices = [Index(value = ["cosplay_id"])]
+)
+data class CosplayTask(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    @ColumnInfo(name = "cosplay_id") val cosplayId: Int,
+    @ColumnInfo(name = "task_name") val taskName: String,
+    @ColumnInfo(name = "done") val done: Boolean,
+    @ColumnInfo(name = "alarm") val alarm: Boolean,
+    @ColumnInfo(name = "notes") val notes: String?
+)

--- a/app/src/main/java/com/example/conquest/data/entity/Cosplays.kt
+++ b/app/src/main/java/com/example/conquest/data/entity/Cosplays.kt
@@ -2,8 +2,6 @@ package com.example.conquest.data.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
-import androidx.room.ForeignKey
-import androidx.room.Index
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverter
 import java.util.Date
@@ -18,20 +16,6 @@ data class Cosplay(
     @ColumnInfo(name = "initial_date") val initialDate: Date,
     @ColumnInfo(name = "due_date") val dueDate: Date?,
     @ColumnInfo(name = "budget") val budget: Double?
-)
-
-@Entity(
-    tableName = "cosplay_photos", foreignKeys = [ForeignKey(
-        entity = Cosplay::class,
-        parentColumns = ["uid"],
-        childColumns = ["cosplay_id"],
-        onDelete = ForeignKey.CASCADE
-    )], indices = [Index(value = ["cosplay_id"])]
-)
-data class CosplayPhoto(
-    @PrimaryKey(autoGenerate = true) val id: Int = 0,
-    @ColumnInfo(name = "cosplay_id") val cosplayId: Int,
-    @ColumnInfo(name = "path") val path: String
 )
 
 class DateConverter {

--- a/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
@@ -9,15 +9,97 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
+import androidx.navigation.toRoute
 import com.example.conquest.components.MyFab
-
+import androidx.compose.foundation.border
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.*
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.conquest.CosplayViewModel
 
 @Composable
-fun CosplayElementsTab() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Cosplay Elements Content")
+fun CosplayElementsTab(navController: NavController, navBackStackEntry: NavBackStackEntry) {
+    val mainArgs = navBackStackEntry.toRoute<MainCosplayScreen>()
+    val cosplayId = mainArgs.uid
+
+    val cosplayViewModel: CosplayViewModel = viewModel()
+
+    LaunchedEffect(cosplayId) {
+        cosplayViewModel.setElementCosplayId(cosplayId)
+    }
+
+    val elements by cosplayViewModel.elements.collectAsState()
+
+    var selectionMode by remember { mutableStateOf(false) }
+    var selectedIds by remember { mutableStateOf(setOf<Int>()) }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(18.dp)
+        ) {
+            items(elements) { element ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(32.dp))
+                        .border(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outline,
+                            shape = RoundedCornerShape(32.dp)
+                        )
+                        .combinedClickable(onClick = {}, onLongClick = {
+                            selectionMode = true
+                            selectedIds = selectedIds + element.id
+                        }),
+                    colors = CardDefaults.cardColors(
+                        containerColor = if (selectedIds.contains(element.id)) MaterialTheme.colorScheme.secondaryContainer
+                        else MaterialTheme.colorScheme.background
+                    ),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+                    shape = RoundedCornerShape(32.dp)) {
+                    Column(
+                        modifier = Modifier.padding(16.dp)
+                    ) {
+                        Text(
+                            text = element.name,
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        if (element.cost != null) {
+                            Text(
+                                text = "Cost: $${element.cost}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onBackground
+                            )
+                        }
+                        Row {
+                            if (element.ready) Text(
+                                "Ready", color = MaterialTheme.colorScheme.secondary
+                            )
+                            if (element.bought) Text(
+                                " • Bought", color = MaterialTheme.colorScheme.secondary
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
         MyFab(
-            onClick = {},
+            onClick = { navController.navigate(NewCosplayElementScreen(cosplayId)) },
             modifier = Modifier.align(Alignment.BottomCenter),
             containerColor = MaterialTheme.colorScheme.tertiary,
             contentColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
@@ -2,6 +2,9 @@ package com.example.conquest.screens
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -15,7 +18,11 @@ fun CosplayElementsTab() {
         Text("Cosplay Elements Content")
         MyFab(
             onClick = {},
-            modifier = Modifier.align(Alignment.BottomCenter)
+            modifier = Modifier.align(Alignment.BottomCenter),
+            containerColor = MaterialTheme.colorScheme.tertiary,
+            contentColor = MaterialTheme.colorScheme.primary,
+            icon = Icons.Default.Add,
+            contentDescription = "Add"
         )
     }
 }

--- a/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
@@ -1,0 +1,16 @@
+package com.example.conquest.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+
+@Composable
+fun CosplayElementsTab() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("Cosplay Elements Content")
+    }
+}

--- a/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
@@ -19,11 +19,13 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.*
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.conquest.CosplayViewModel
 
@@ -44,6 +46,23 @@ fun CosplayElementsTab(navController: NavController, navBackStackEntry: NavBackS
     var selectedIds by remember { mutableStateOf(setOf<Int>()) }
 
     Box(modifier = Modifier.fillMaxSize()) {
+        if (selectionMode) {
+            MyFab(
+                onClick = {
+                    cosplayViewModel.deleteElementsByIds(selectedIds)
+                    selectionMode = false
+                    selectedIds = emptySet()
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .zIndex(2f),
+                containerColor = MaterialTheme.colorScheme.secondary,
+                contentColor = MaterialTheme.colorScheme.primary,
+                icon = Icons.Default.Close,
+                contentDescription = "Delete",
+            )
+        }
+
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
@@ -60,7 +79,16 @@ fun CosplayElementsTab(navController: NavController, navBackStackEntry: NavBackS
                             color = MaterialTheme.colorScheme.outline,
                             shape = RoundedCornerShape(32.dp)
                         )
-                        .combinedClickable(onClick = {}, onLongClick = {
+                        .combinedClickable(onClick = {
+                            if (selectionMode) {
+                                val id = element.id
+                                selectedIds =
+                                    if (selectedIds.contains(id)) selectedIds - id else selectedIds + id
+                                if (selectedIds.isEmpty()) selectionMode = false
+                            } else {
+//                                navController.navigate(MainCosplayScreen(cosplay.uid))
+                            }
+                        }, onLongClick = {
                             selectionMode = true
                             selectedIds = selectedIds + element.id
                         }),

--- a/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
@@ -6,11 +6,16 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.example.conquest.components.MyFab
 
 
 @Composable
 fun CosplayElementsTab() {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Text("Cosplay Elements Content")
+        MyFab(
+            onClick = {},
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
     }
 }

--- a/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
@@ -18,16 +18,23 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.*
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
 import com.example.conquest.CosplayViewModel
+import androidx.compose.foundation.background
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material3.Icon
+
 
 @Composable
 fun CosplayElementsTab(navController: NavController, navBackStackEntry: NavBackStackEntry) {
@@ -86,7 +93,7 @@ fun CosplayElementsTab(navController: NavController, navBackStackEntry: NavBackS
                                     if (selectedIds.contains(id)) selectedIds - id else selectedIds + id
                                 if (selectedIds.isEmpty()) selectionMode = false
                             } else {
-//                                navController.navigate(MainCosplayScreen(cosplay.uid))
+                                // navController.navigate(...)
                             }
                         }, onLongClick = {
                             selectionMode = true
@@ -98,28 +105,77 @@ fun CosplayElementsTab(navController: NavController, navBackStackEntry: NavBackS
                     ),
                     elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
                     shape = RoundedCornerShape(32.dp)) {
-                    Column(
-                        modifier = Modifier.padding(16.dp)
+                    Row(
+                        modifier = Modifier
+                            .padding(12.dp)
+                            .fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        Text(
-                            text = element.name,
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                        if (element.cost != null) {
-                            Text(
-                                text = "Cost: $${element.cost}",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onBackground
+                        // Image or placeholder
+                        if (element.photoPath != "") {
+                            AsyncImage(
+                                model = element.photoPath,
+                                contentDescription = "Element image",
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier
+                                    .size(64.dp)
+                                    .clip(CircleShape)
                             )
+                        } else {
+                            Box(
+                                modifier = Modifier
+                                    .size(64.dp)
+                                    .clip(CircleShape)
+                                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Image,
+                                    contentDescription = "Placeholder image",
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
                         }
-                        Row {
-                            if (element.ready) Text(
-                                "Ready", color = MaterialTheme.colorScheme.secondary
+
+                        // Text content
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                text = element.name,
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.primary
                             )
-                            if (element.bought) Text(
-                                " • Bought", color = MaterialTheme.colorScheme.secondary
-                            )
+                            if (element.cost != null) {
+                                Text(
+                                    text = "Cost: $${element.cost}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onBackground
+                                )
+                            }
+                        }
+
+                        // Status labels in one line
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            if (element.ready) {
+                                Text(
+                                    "Ready",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.secondary
+                                )
+                            }
+                            if (element.bought) {
+                                Text(
+                                    "Bought",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.secondary
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
@@ -93,7 +93,7 @@ fun CosplayElementsTab(navController: NavController, navBackStackEntry: NavBackS
                                     if (selectedIds.contains(id)) selectedIds - id else selectedIds + id
                                 if (selectedIds.isEmpty()) selectionMode = false
                             } else {
-                                // navController.navigate(...)
+                                navController.navigate(EditCosplayElementScreen(element.id))
                             }
                         }, onLongClick = {
                             selectionMode = true
@@ -104,7 +104,8 @@ fun CosplayElementsTab(navController: NavController, navBackStackEntry: NavBackS
                         else MaterialTheme.colorScheme.background
                     ),
                     elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-                    shape = RoundedCornerShape(32.dp)) {
+                    shape = RoundedCornerShape(32.dp)
+                ) {
                     Row(
                         modifier = Modifier
                             .padding(12.dp)

--- a/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
@@ -114,7 +114,7 @@ fun CosplayElementsTab(navController: NavController, navBackStackEntry: NavBackS
                         horizontalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
                         // Image or placeholder
-                        if (element.photoPath.isNullOrEmpty()) {
+                        if (!element.photoPath.isNullOrEmpty()) {
                             AsyncImage(
                                 model = element.photoPath,
                                 contentDescription = "Element image",

--- a/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
@@ -114,7 +114,7 @@ fun CosplayElementsTab(navController: NavController, navBackStackEntry: NavBackS
                         horizontalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
                         // Image or placeholder
-                        if (element.photoPath != "") {
+                        if (element.photoPath.isNullOrEmpty()) {
                             AsyncImage(
                                 model = element.photoPath,
                                 contentDescription = "Element image",

--- a/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/CosplayElementsTab.kt
@@ -119,13 +119,13 @@ fun CosplayElementsTab(navController: NavController, navBackStackEntry: NavBackS
                                 contentDescription = "Element image",
                                 contentScale = ContentScale.Crop,
                                 modifier = Modifier
-                                    .size(64.dp)
+                                    .size(48.dp)
                                     .clip(CircleShape)
                             )
                         } else {
                             Box(
                                 modifier = Modifier
-                                    .size(64.dp)
+                                    .size(48.dp)
                                     .clip(CircleShape)
                                     .background(MaterialTheme.colorScheme.surfaceVariant),
                                 contentAlignment = Alignment.Center

--- a/app/src/main/java/com/example/conquest/screens/EditCosplayElementScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/EditCosplayElementScreen.kt
@@ -1,0 +1,195 @@
+package com.example.conquest.screens
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts.GetContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import coil.compose.AsyncImage
+import com.example.conquest.CosplayViewModel
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EditCosplayElementScreen(val elementId: Int)
+
+@Composable
+fun EditCosplayElementScreen(
+    elementId: Int, navController: NavController, cosplayViewModel: CosplayViewModel = viewModel()
+) {
+    val context = LocalContext.current
+    val element by cosplayViewModel.getElementById(elementId).collectAsState(initial = null)
+
+    var name by remember { mutableStateOf("") }
+    var cost by remember { mutableStateOf("") }
+    var ready by remember { mutableStateOf(false) }
+    var bought by remember { mutableStateOf(false) }
+    var photoPath by remember { mutableStateOf("") }
+    var notes by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf("") }
+
+// Image picker launcher
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = GetContent()
+    ) { uri: Uri? ->
+        if (uri != null) {
+            try {
+                val fileName = "cosplay_element_${System.currentTimeMillis()}.jpg"
+                val savedPath = copyUriToInternalStorage(context, uri, fileName)
+                photoPath = savedPath
+            } catch (e: Exception) {
+                error = "Failed to save image: ${e.localizedMessage}"
+            }
+        }
+    }
+
+// Load element data
+    LaunchedEffect(element) {
+        element?.let {
+            name = it.name
+            cost = it.cost?.toString() ?: ""
+            ready = it.ready
+            bought = it.bought
+            photoPath = it.photoPath ?: ""
+            notes = it.notes ?: ""
+        }
+    }
+
+// Scrollable content so Save button is always visible
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp) // reduced horizontal padding
+            .padding(top = 12.dp),       // reduced top padding
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // Image section with less padding
+        Text(
+            text = "Element Image",
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+        )
+        Box(
+            modifier = Modifier
+                .size(80.dp) // smaller image size
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .clickable { imagePickerLauncher.launch("image/*") },
+            contentAlignment = Alignment.Center
+        ) {
+            if (photoPath.isNotEmpty()) {
+                AsyncImage(
+                    model = photoPath,
+                    contentDescription = "Element image",
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(CircleShape)
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Default.Image,
+                    contentDescription = "Pick image",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        if (error.isNotEmpty()) {
+            Text(error, color = MaterialTheme.colorScheme.error)
+        }
+
+        // Inputs with more rounded corners
+        Text(
+            text = "Basic Information",
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+        )
+        OutlinedTextField(
+            value = name,
+            onValueChange = { name = it },
+            label = { Text("Name") },
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(20.dp), // more rounded
+            singleLine = true
+        )
+
+        OutlinedTextField(
+            value = cost,
+            onValueChange = { cost = it },
+            label = { Text("Cost") },
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(20.dp), // more rounded
+            singleLine = true
+        )
+
+        Text(
+            text = "Status",
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(checked = ready, onCheckedChange = { ready = it })
+                Text("Ready")
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(checked = bought, onCheckedChange = { bought = it })
+                Text("Bought")
+            }
+        }
+
+        Text(
+            text = "Notes",
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+        )
+        OutlinedTextField(
+            value = notes,
+            onValueChange = { notes = it },
+            label = { Text("Notes") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp),
+            shape = RoundedCornerShape(20.dp), // more rounded
+            maxLines = 6
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Save button always visible
+        Button(
+            onClick = {
+                cosplayViewModel.updateElement(
+                    id = elementId,
+                    name = name,
+                    cost = cost.toDoubleOrNull(),
+                    ready = ready,
+                    bought = bought,
+                    photoPath = photoPath,
+                    notes = notes
+                )
+                navController.popBackStack()
+            }, modifier = Modifier
+                .fillMaxWidth()
+                .height(50.dp), // consistent button height
+            shape = RoundedCornerShape(20.dp) // more rounded
+        ) {
+            Text("Save", style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}

--- a/app/src/main/java/com/example/conquest/screens/EditCosplayElementScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/EditCosplayElementScreen.kt
@@ -4,12 +4,15 @@ import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.GetContent
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -23,6 +26,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import com.example.conquest.CosplayViewModel
+import com.example.conquest.components.MyFab
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -43,7 +47,7 @@ fun EditCosplayElementScreen(
     var notes by remember { mutableStateOf("") }
     var error by remember { mutableStateOf("") }
 
-// Image picker launcher
+    // Image picker launcher
     val imagePickerLauncher = rememberLauncherForActivityResult(
         contract = GetContent()
     ) { uri: Uri? ->
@@ -58,7 +62,7 @@ fun EditCosplayElementScreen(
         }
     }
 
-// Load element data
+    // Load element data
     LaunchedEffect(element) {
         element?.let {
             name = it.name
@@ -70,126 +74,194 @@ fun EditCosplayElementScreen(
         }
     }
 
-// Scrollable content so Save button is always visible
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 16.dp) // reduced horizontal padding
-            .padding(top = 12.dp),       // reduced top padding
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        // Image section with less padding
-        Text(
-            text = "Element Image",
-            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
-        )
-        Box(
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
             modifier = Modifier
-                .size(80.dp) // smaller image size
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.surfaceVariant)
-                .clickable { imagePickerLauncher.launch("image/*") },
-            contentAlignment = Alignment.Center
+                .fillMaxSize()
+                .padding(horizontal = 16.dp)
+                .padding(top = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            if (photoPath.isNotEmpty()) {
-                AsyncImage(
-                    model = photoPath,
-                    contentDescription = "Element image",
-                    contentScale = ContentScale.Crop,
+            Text(
+                text = "Element Image",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+            )
+            Box(
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .clickable { imagePickerLauncher.launch("image/*") },
+                contentAlignment = Alignment.Center
+            ) {
+                if (photoPath.isNotEmpty()) {
+                    AsyncImage(
+                        model = photoPath,
+                        contentDescription = "Element image",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clip(CircleShape)
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Default.Image,
+                        contentDescription = "Pick image",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            if (error.isNotEmpty()) {
+                Text(error, color = MaterialTheme.colorScheme.error)
+            }
+
+            Text(
+                text = "Basic Information",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+            )
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Name") },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(20.dp),
+                singleLine = true
+            )
+
+            OutlinedTextField(
+                value = cost,
+                onValueChange = { cost = it },
+                label = { Text("Cost") },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(20.dp),
+                singleLine = true
+            )
+
+            Text(
+                text = "Status",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Ready switch
+                Card(
                     modifier = Modifier
-                        .fillMaxSize()
-                        .clip(CircleShape)
-                )
-            } else {
-                Icon(
-                    imageVector = Icons.Default.Image,
-                    contentDescription = "Pick image",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .border(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outline,
+                            shape = RoundedCornerShape(32.dp)
+                        ),
+                    shape = RoundedCornerShape(32.dp),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 18.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Text(text = "Ready")
+                        Switch(
+                            checked = ready,
+                            onCheckedChange = { ready = it },
+                            colors = SwitchDefaults.colors(
+                                checkedThumbColor = MaterialTheme.colorScheme.primary,
+                                checkedTrackColor = MaterialTheme.colorScheme.secondary,
+                                uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                uncheckedTrackColor = MaterialTheme.colorScheme.secondary
+                            )
+                        )
+                    }
+                }
+                Card(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .border(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outline,
+                            shape = RoundedCornerShape(32.dp)
+                        ),
+                    shape = RoundedCornerShape(32.dp),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 18.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Text(text = "Bought")
+                        Switch(
+                            checked = bought,
+                            onCheckedChange = { bought = it },
+                            colors = SwitchDefaults.colors(
+                                checkedThumbColor = MaterialTheme.colorScheme.primary,
+                                checkedTrackColor = MaterialTheme.colorScheme.secondary,
+                                uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                uncheckedTrackColor = MaterialTheme.colorScheme.secondary
+                            )
+                        )
+                    }
+                }
             }
+
+            Text(
+                text = "Notes",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+            )
+            OutlinedTextField(
+                value = notes,
+                onValueChange = { notes = it },
+                label = { Text("Notes") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(120.dp),
+                shape = RoundedCornerShape(20.dp),
+                maxLines = 6
+            )
         }
 
-        if (error.isNotEmpty()) {
-            Text(error, color = MaterialTheme.colorScheme.error)
-        }
-
-        // Inputs with more rounded corners
-        Text(
-            text = "Basic Information",
-            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
-        )
-        OutlinedTextField(
-            value = name,
-            onValueChange = { name = it },
-            label = { Text("Name") },
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(20.dp), // more rounded
-            singleLine = true
-        )
-
-        OutlinedTextField(
-            value = cost,
-            onValueChange = { cost = it },
-            label = { Text("Cost") },
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(20.dp), // more rounded
-            singleLine = true
-        )
-
-        Text(
-            text = "Status",
-            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
-        )
+        // ✅ Row with two FABs centered at bottom
         Row(
-            horizontalArrangement = Arrangement.spacedBy(24.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Checkbox(checked = ready, onCheckedChange = { ready = it })
-                Text("Ready")
-            }
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Checkbox(checked = bought, onCheckedChange = { bought = it })
-                Text("Bought")
-            }
-        }
-
-        Text(
-            text = "Notes",
-            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
-        )
-        OutlinedTextField(
-            value = notes,
-            onValueChange = { notes = it },
-            label = { Text("Notes") },
             modifier = Modifier
-                .fillMaxWidth()
-                .height(120.dp),
-            shape = RoundedCornerShape(20.dp), // more rounded
-            maxLines = 6
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        // Save button always visible
-        Button(
-            onClick = {
-                cosplayViewModel.updateElement(
-                    id = elementId,
-                    name = name,
-                    cost = cost.toDoubleOrNull(),
-                    ready = ready,
-                    bought = bought,
-                    photoPath = photoPath,
-                    notes = notes
-                )
-                navController.popBackStack()
-            }, modifier = Modifier
-                .fillMaxWidth()
-                .height(50.dp), // consistent button height
-            shape = RoundedCornerShape(20.dp) // more rounded
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(24.dp)
         ) {
-            Text("Save", style = MaterialTheme.typography.titleMedium)
+            MyFab(
+                onClick = { navController.popBackStack() },
+                containerColor = MaterialTheme.colorScheme.errorContainer,
+                contentColor = MaterialTheme.colorScheme.primary,
+                icon = Icons.Default.Close,
+                contentDescription = "Discard"
+            )
+
+            MyFab(
+                onClick = {
+                    cosplayViewModel.updateElement(
+                        id = elementId,
+                        name = name,
+                        cost = cost.toDoubleOrNull(),
+                        ready = ready,
+                        bought = bought,
+                        photoPath = photoPath,
+                        notes = notes
+                    )
+                    navController.popBackStack()
+                },
+                containerColor = MaterialTheme.colorScheme.secondary,
+                contentColor = MaterialTheme.colorScheme.primary,
+                icon = Icons.Default.Check,
+                contentDescription = "Save"
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/conquest/screens/EditCosplayElementScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/EditCosplayElementScreen.kt
@@ -246,15 +246,17 @@ fun EditCosplayElementScreen(
 
             MyFab(
                 onClick = {
-                    cosplayViewModel.updateElement(
-                        id = elementId,
-                        name = name,
-                        cost = cost.toDoubleOrNull(),
-                        ready = ready,
-                        bought = bought,
-                        photoPath = photoPath,
-                        notes = notes
-                    )
+                    element?.let {
+                        val updatedElement = it.copy(
+                            name = name,
+                            cost = cost.toDoubleOrNull(),
+                            ready = ready,
+                            bought = bought,
+                            photoPath = photoPath,
+                            notes = notes
+                        )
+                        cosplayViewModel.updateElement(updatedElement)
+                    }
                     navController.popBackStack()
                 },
                 containerColor = MaterialTheme.colorScheme.secondary,

--- a/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.TheaterComedy
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation.NavController
 
 @Serializable
 data class MainCosplayScreen(
@@ -23,9 +24,10 @@ data class MainCosplayScreen(
 
 @Composable
 fun MainCosplayScreen(
-    navBackStackEntry: NavBackStackEntry
+    navBackStackEntry: NavBackStackEntry,
+    navController: NavController
 ) {
-    CosplayTabs(navBackStackEntry)
+    CosplayTabs(navBackStackEntry, navController)
 }
 
 data class TabIcon(
@@ -33,7 +35,7 @@ data class TabIcon(
 )
 
 @Composable
-fun CosplayTabs(navBackStackEntry: NavBackStackEntry) {
+fun CosplayTabs(navBackStackEntry: NavBackStackEntry, navController: NavController) {
     val tabIcons = listOf(
         TabIcon(Icons.Filled.TheaterComedy, "Cosplay Elements"),
         TabIcon(Icons.AutoMirrored.Filled.List, "Tasks"),
@@ -65,7 +67,7 @@ fun CosplayTabs(navBackStackEntry: NavBackStackEntry) {
             state = pagerState, modifier = Modifier.weight(1f)
         ) { page ->
             when (page) {
-                0 -> CosplayElementsTab()
+                0 -> CosplayElementsTab(navController, navBackStackEntry)
                 1 -> TasksTab()
                 2 -> ReferenceImagesTab(navBackStackEntry)
             }

--- a/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
@@ -24,8 +24,7 @@ data class MainCosplayScreen(
 
 @Composable
 fun MainCosplayScreen(
-    navBackStackEntry: NavBackStackEntry,
-    navController: NavController
+    navBackStackEntry: NavBackStackEntry, navController: NavController
 ) {
     CosplayTabs(navBackStackEntry, navController)
 }
@@ -68,7 +67,7 @@ fun CosplayTabs(navBackStackEntry: NavBackStackEntry, navController: NavControll
         ) { page ->
             when (page) {
                 0 -> CosplayElementsTab(navController, navBackStackEntry)
-                1 -> TasksTab()
+                1 -> CosplayTasksTab(navController, navBackStackEntry)
                 2 -> ReferenceImagesTab(navBackStackEntry)
             }
         }

--- a/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
@@ -1,34 +1,13 @@
 package com.example.conquest.screens
 
-import android.content.Context
-import android.net.Uri
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavBackStackEntry
-import androidx.navigation.toRoute
-import com.example.conquest.CosplayViewModel
-import com.example.conquest.data.entity.CosplayPhoto
 import kotlinx.serialization.Serializable
-import java.io.File
-import java.io.InputStream
-import java.io.OutputStream
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Text
-import coil.compose.AsyncImage
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
@@ -47,67 +26,6 @@ fun MainCosplayScreen(
     navBackStackEntry: NavBackStackEntry
 ) {
     CosplayTabs(navBackStackEntry)
-}
-
-@Composable
-fun PickAndSaveImage(
-    context: Context, onImageSaved: (String) -> Unit
-) {
-    var error by remember { mutableStateOf<String?>("") }
-
-    val launcher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent()
-    ) { uri: Uri? ->
-        if (uri != null) {
-            try {
-                val fileName = "cosplay_photo_${System.currentTimeMillis()}.jpg"
-                val savedPath = copyUriToInternalStorage(context, uri, fileName)
-                onImageSaved(savedPath)
-            } catch (e: Exception) {
-                error = "Failed to save image: ${e.localizedMessage}"
-            }
-        }
-    }
-
-    Button(onClick = { launcher.launch("image/*") }) {
-        Text("Pick Photo")
-    }
-
-    error?.let {
-        Text(it, color = MaterialTheme.colorScheme.error)
-    }
-}
-
-fun copyUriToInternalStorage(context: Context, uri: Uri, fileName: String): String {
-    val inputStream: InputStream? = context.contentResolver.openInputStream(uri)
-    val file = File(context.filesDir, fileName)
-    val outputStream: OutputStream = file.outputStream()
-
-    inputStream?.use { input ->
-        outputStream.use { output ->
-            input.copyTo(output)
-        }
-    }
-    return file.absolutePath
-}
-
-@Composable
-fun CosplayPhotoList(photos: List<CosplayPhoto>) {
-    if (photos.isEmpty()) {
-        Text("No photos yet.")
-    } else {
-        LazyRow(
-            modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            items(photos) { photo ->
-                AsyncImage(
-                    model = photo.path,
-                    contentDescription = "Cosplay photo",
-                    modifier = Modifier.size(120.dp)
-                )
-            }
-        }
-    }
 }
 
 data class TabIcon(
@@ -137,8 +55,7 @@ fun CosplayTabs(navBackStackEntry: NavBackStackEntry) {
             tabIcons.forEachIndexed { index, icon ->
                 Tab(icon = {
                     Icon(
-                        imageVector = icon.imageVector,
-                        contentDescription = icon.contentDescription
+                        imageVector = icon.imageVector, contentDescription = icon.contentDescription
                     )
                 }, selected = pagerState.currentPage == index, onClick = { selectedTab = index })
             }
@@ -153,48 +70,5 @@ fun CosplayTabs(navBackStackEntry: NavBackStackEntry) {
                 2 -> ReferenceImagesTab(navBackStackEntry)
             }
         }
-    }
-}
-
-@Composable
-fun CosplayElementsTab() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Cosplay Elements Content")
-    }
-}
-
-@Composable
-fun TasksTab() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Tasks Content")
-    }
-}
-
-@Composable
-fun ReferenceImagesTab(navBackStackEntry: NavBackStackEntry) {
-    val args = navBackStackEntry.toRoute<MainCosplayScreen>()
-    val context = LocalContext.current
-    val cosplayViewModel: CosplayViewModel = viewModel()
-
-    LaunchedEffect(args.uid) {
-        cosplayViewModel.setCosplayId(args.uid)
-    }
-
-    val photos by cosplayViewModel.photos.collectAsState()
-
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Top,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-
-        PickAndSaveImage(context) { savedPath ->
-            cosplayViewModel.addPhoto(args.uid, savedPath)
-        }
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        Text("All Photos:")
-        CosplayPhotoList(photos)
     }
 }

--- a/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
@@ -33,8 +33,8 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
-import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.TheaterComedy
 import androidx.compose.ui.graphics.vector.ImageVector
 
 @Serializable
@@ -117,7 +117,7 @@ data class TabIcon(
 @Composable
 fun CosplayTabs(navBackStackEntry: NavBackStackEntry) {
     val tabIcons = listOf(
-        TabIcon(Icons.Filled.AccountCircle, "Cosplay Elements"),
+        TabIcon(Icons.Filled.TheaterComedy, "Cosplay Elements"),
         TabIcon(Icons.AutoMirrored.Filled.List, "Tasks"),
         TabIcon(Icons.Filled.Image, "Reference Images")
     )

--- a/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
@@ -1,29 +1,132 @@
 package com.example.conquest.screens
 
+import android.content.Context
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.toRoute
+import com.example.conquest.CosplayViewModel
+import com.example.conquest.data.entity.CosplayPhoto
 import kotlinx.serialization.Serializable
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import coil.compose.AsyncImage
 
 @Serializable
 data class MainCosplayScreen(
     val uid: Int
 )
 
+
 @Composable
-fun MainCosplayScreen(navBackStackEntry: NavBackStackEntry) {
+fun MainCosplayScreen(
+    navBackStackEntry: NavBackStackEntry
+) {
     val args = navBackStackEntry.toRoute<MainCosplayScreen>()
+    val context = LocalContext.current
+    val cosplayViewModel: CosplayViewModel = viewModel()
+
+    LaunchedEffect(args.uid) {
+        cosplayViewModel.setCosplayId(args.uid)
+    }
+
+    val photos by cosplayViewModel.photos.collectAsState()
+
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(text = "Cosplay UID: ${args.uid}")
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        PickAndSaveImage(context) { savedPath ->
+            cosplayViewModel.addPhoto(args.uid, savedPath)
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text("All Photos:")
+        CosplayPhotoList(photos)
+    }
+}
+
+@Composable
+fun PickAndSaveImage(
+    context: Context, onImageSaved: (String) -> Unit
+) {
+    var error by remember { mutableStateOf<String?>("") }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        if (uri != null) {
+            try {
+                val fileName = "cosplay_photo_${System.currentTimeMillis()}.jpg"
+                val savedPath = copyUriToInternalStorage(context, uri, fileName)
+                onImageSaved(savedPath)
+            } catch (e: Exception) {
+                error = "Failed to save image: ${e.localizedMessage}"
+            }
+        }
+    }
+
+    Button(onClick = { launcher.launch("image/*") }) {
+        Text("Pick Photo")
+    }
+
+    error?.let {
+        Text(it, color = MaterialTheme.colorScheme.error)
+    }
+}
+
+fun copyUriToInternalStorage(context: Context, uri: Uri, fileName: String): String {
+    val inputStream: InputStream? = context.contentResolver.openInputStream(uri)
+    val file = File(context.filesDir, fileName)
+    val outputStream: OutputStream = file.outputStream()
+
+    inputStream?.use { input ->
+        outputStream.use { output ->
+            input.copyTo(output)
+        }
+    }
+    return file.absolutePath
+}
+
+@Composable
+fun CosplayPhotoList(photos: List<CosplayPhoto>) {
+    if (photos.isEmpty()) {
+        Text("No photos yet.")
+    } else {
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(photos) { photo ->
+                AsyncImage(
+                    model = photo.path,
+                    contentDescription = "Cosplay photo",
+                    modifier = Modifier.size(120.dp)
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavBackStackEntry
 import kotlinx.serialization.Serializable
-import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
@@ -16,17 +15,24 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.TheaterComedy
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavController
+import androidx.navigation.toRoute
+import kotlinx.coroutines.launch
 
 @Serializable
 data class MainCosplayScreen(
-    val uid: Int
+    val uid: Int, val initialTab: Int = 0
 )
 
 @Composable
 fun MainCosplayScreen(
     navBackStackEntry: NavBackStackEntry, navController: NavController
 ) {
-    CosplayTabs(navBackStackEntry, navController)
+    val args = navBackStackEntry.toRoute<MainCosplayScreen>()
+    CosplayTabs(
+        navBackStackEntry = navBackStackEntry,
+        navController = navController,
+        initialTab = args.initialTab
+    )
 }
 
 data class TabIcon(
@@ -34,31 +40,29 @@ data class TabIcon(
 )
 
 @Composable
-fun CosplayTabs(navBackStackEntry: NavBackStackEntry, navController: NavController) {
+fun CosplayTabs(
+    navBackStackEntry: NavBackStackEntry, navController: NavController, initialTab: Int
+) {
     val tabIcons = listOf(
         TabIcon(Icons.Filled.TheaterComedy, "Cosplay Elements"),
         TabIcon(Icons.AutoMirrored.Filled.List, "Tasks"),
         TabIcon(Icons.Filled.Image, "Reference Images")
     )
-    val pagerState = rememberPagerState { tabIcons.size }
-    var selectedTab by remember { mutableIntStateOf(0) }
 
-    LaunchedEffect(selectedTab) {
-        if (pagerState.currentPage != selectedTab) {
-            pagerState.animateScrollToPage(selectedTab)
-        }
-    }
+    val pagerState = rememberPagerState(initialPage = initialTab) { tabIcons.size }
+    val coroutineScope = rememberCoroutineScope()
 
     Column(modifier = Modifier.fillMaxSize()) {
-        TabRow(
-            selectedTabIndex = pagerState.currentPage, modifier = Modifier.fillMaxWidth()
-        ) {
+        TabRow(selectedTabIndex = pagerState.currentPage) {
             tabIcons.forEachIndexed { index, icon ->
-                Tab(icon = {
-                    Icon(
-                        imageVector = icon.imageVector, contentDescription = icon.contentDescription
-                    )
-                }, selected = pagerState.currentPage == index, onClick = { selectedTab = index })
+                Tab(
+                    icon = { Icon(icon.imageVector, icon.contentDescription) },
+                    selected = pagerState.currentPage == index,
+                    onClick = {
+                        coroutineScope.launch {
+                            pagerState.animateScrollToPage(index)
+                        }
+                    })
             }
         }
 

--- a/app/src/main/java/com/example/conquest/screens/MainScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/MainScreen.kt
@@ -57,7 +57,9 @@ fun MainScreen(navController: NavController, searchQuery: String) {
                     selectionMode = false
                     selectedIds = emptySet()
                 },
-                modifier = Modifier.align(Alignment.BottomCenter).zIndex(2f),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .zIndex(2f),
                 containerColor = MaterialTheme.colorScheme.secondary,
                 contentColor = MaterialTheme.colorScheme.primary,
                 icon = Icons.Default.Close,

--- a/app/src/main/java/com/example/conquest/screens/MainScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/MainScreen.kt
@@ -51,9 +51,7 @@ fun MainScreen(navController: NavController, searchQuery: String) {
         if (selectionMode) {
             MyFab(
                 onClick = {
-                    filteredCosplays.filter { selectedIds.contains(it.uid) }.forEach {
-                        cosplayViewModel.deleteCosplay(it)
-                    }
+                    cosplayViewModel.deleteCosplaysByIds(selectedIds)
                     selectionMode = false
                     selectedIds = emptySet()
                 },

--- a/app/src/main/java/com/example/conquest/screens/MainScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/MainScreen.kt
@@ -6,14 +6,19 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.conquest.CosplayViewModel
@@ -36,40 +41,58 @@ fun MainScreen(navController: NavController, searchQuery: String) {
         else cosplays.filter { it.name.contains(searchQuery, ignoreCase = true) }
     }
 
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(18.dp)
+    Box(
+        modifier = Modifier.fillMaxSize()
     ) {
-        items(filteredCosplays) { cosplay ->
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(32.dp))
-                    .border(
-                        width = 1.dp,
-                        color = MaterialTheme.colorScheme.outline,
-                        shape = RoundedCornerShape(32.dp)
-                    )
-                    .clickable {
-                        navController.navigate(MainCosplayScreen(cosplay.uid))
-                    },
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
-                elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-                shape = RoundedCornerShape(32.dp)
-            ) {
-                Column(
-                    modifier = Modifier.padding(16.dp)
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(18.dp)
+        ) {
+            items(filteredCosplays) { cosplay ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(32.dp))
+                        .border(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outline,
+                            shape = RoundedCornerShape(32.dp)
+                        )
+                        .clickable {
+                            navController.navigate(MainCosplayScreen(cosplay.uid))
+                        },
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+                    shape = RoundedCornerShape(32.dp)
                 ) {
-                    Text(
-                        text = cosplay.name,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary
-                    )
+                    Column(
+                        modifier = Modifier.padding(16.dp)
+                    ) {
+                        Text(
+                            text = cosplay.name,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
                 }
             }
+        }
+        FloatingActionButton(
+            onClick = {
+                navController.navigate(NewCosplayScreen)
+            },
+            containerColor = MaterialTheme.colorScheme.tertiary,
+            contentColor = MaterialTheme.colorScheme.primary,
+            shape = RoundedCornerShape(50),
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 16.dp)
+                .statusBarsPadding()
+        ) {
+            Icon(Icons.Default.Add, contentDescription = "Save")
         }
     }
 }

--- a/app/src/main/java/com/example/conquest/screens/MainScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/MainScreen.kt
@@ -6,12 +6,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -27,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.font.FontWeight
+import com.example.conquest.components.MyFab
 
 @Serializable
 object MainScreen
@@ -80,19 +77,9 @@ fun MainScreen(navController: NavController, searchQuery: String) {
                 }
             }
         }
-        FloatingActionButton(
-            onClick = {
-                navController.navigate(NewCosplayScreen)
-            },
-            containerColor = MaterialTheme.colorScheme.tertiary,
-            contentColor = MaterialTheme.colorScheme.primary,
-            shape = RoundedCornerShape(50),
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(bottom = 16.dp)
-                .statusBarsPadding()
-        ) {
-            Icon(Icons.Default.Add, contentDescription = "Save")
-        }
+        MyFab(
+            onClick = { navController.navigate(NewCosplayScreen) },
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
     }
 }

--- a/app/src/main/java/com/example/conquest/screens/NewCosplayElementScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/NewCosplayElementScreen.kt
@@ -1,0 +1,218 @@
+package com.example.conquest.screens
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.conquest.CosplayViewModel
+import com.example.conquest.data.entity.CosplayElement
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NewCosplayElementScreen(val cosplayId: Int)
+
+@Composable
+fun NewCosplayElementScreen(
+    cosplayId: Int,
+    navController: NavController,
+) {
+    val cosplayViewModel: CosplayViewModel = viewModel()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+
+    var name by remember { mutableStateOf("") }
+    var cost by remember { mutableStateOf("") }
+    var ready by remember { mutableStateOf(false) }
+    var highlight by remember { mutableStateOf(false) }
+    var bought by remember { mutableStateOf(false) }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth(0.9f)
+                .padding(top = 70.dp, start = 16.dp, end = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Add Element",
+                style = MaterialTheme.typography.headlineMedium.copy(
+                    fontWeight = FontWeight.Bold, letterSpacing = 1.5.sp
+                ),
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .padding(bottom = 8.dp, top = 8.dp)
+                    .fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
+
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Element Name*") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                shape = RoundedCornerShape(32.dp)
+            )
+
+            OutlinedTextField(
+                value = cost,
+                onValueChange = { cost = it.filter { c -> c.isDigit() || c == '.' } },
+                label = { Text("Cost (Optional)") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                leadingIcon = { Text("$") },
+                shape = RoundedCornerShape(32.dp)
+            )
+
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.outline,
+                        shape = RoundedCornerShape(32.dp)
+                    ),
+                shape = RoundedCornerShape(32.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 18.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(text = "Ready")
+                    Switch(
+                        checked = ready,
+                        onCheckedChange = { ready = it },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = MaterialTheme.colorScheme.primary,
+                            checkedTrackColor = MaterialTheme.colorScheme.secondary,
+                            uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            uncheckedTrackColor = MaterialTheme.colorScheme.secondary
+                        )
+                    )
+                }
+            }
+
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.outline,
+                        shape = RoundedCornerShape(32.dp)
+                    ),
+                shape = RoundedCornerShape(32.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 18.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(text = "Bought")
+                    Switch(
+                        checked = bought,
+                        onCheckedChange = { bought = it },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = MaterialTheme.colorScheme.primary,
+                            checkedTrackColor = MaterialTheme.colorScheme.secondary,
+                            uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            uncheckedTrackColor = MaterialTheme.colorScheme.secondary
+                        )
+                    )
+                }
+            }
+        }
+
+        IconButton(
+            onClick = { navController.popBackStack() },
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(top = 16.dp, end = 16.dp)
+                .statusBarsPadding()
+                .size(60.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Cancel,
+                contentDescription = "Cancel",
+                tint = MaterialTheme.colorScheme.onBackground
+            )
+        }
+
+        Box(
+            modifier = Modifier.align(Alignment.BottomCenter)
+        ) {
+            FloatingActionButton(
+                onClick = {
+                    if (name.isNotBlank()) {
+                        val element = CosplayElement(
+                            id = 0,
+                            cosplayId = cosplayId,
+                            name = name.trim(),
+                            cost = cost.takeIf { it.isNotBlank() }?.toDoubleOrNull(),
+                            ready = ready,
+                            photoPath = null,
+                            highlight = highlight,
+                            bought = bought,
+                            notes = null
+                        )
+                        cosplayViewModel.insertElement(element)
+                        navController.popBackStack()
+                    } else {
+                        coroutineScope.launch {
+                            snackbarHostState.showSnackbar(
+                                message = "Please fill out all required fields!"
+                            )
+                        }
+                    }
+                },
+                containerColor = MaterialTheme.colorScheme.secondary,
+                contentColor = MaterialTheme.colorScheme.primary,
+                shape = RoundedCornerShape(50),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 16.dp)
+                    .navigationBarsPadding()
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Save")
+            }
+        }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 16.dp, vertical = 140.dp),
+            snackbar = { data ->
+                Snackbar(
+                    snackbarData = data,
+                    containerColor = MaterialTheme.colorScheme.tertiary,
+                    contentColor = MaterialTheme.colorScheme.primary,
+                    shape = RoundedCornerShape(32.dp),
+                )
+            })
+    }
+}

--- a/app/src/main/java/com/example/conquest/screens/NewCosplayElementScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/NewCosplayElementScreen.kt
@@ -3,18 +3,23 @@ package com.example.conquest.screens
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -106,21 +111,61 @@ fun NewCosplayElementScreen(
                 shape = RoundedCornerShape(32.dp)
             )
 
-            // Image picker button
             Button(
-                onClick = { launcher.launch("image/*") }, shape = RoundedCornerShape(32.dp)
+                onClick = { launcher.launch("image/*") },
+                shape = RoundedCornerShape(50),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.tertiary,
+                    contentColor = MaterialTheme.colorScheme.primary
+                ),
+                modifier = Modifier
+                    .height(48.dp)
+                    .padding(horizontal = 8.dp)
             ) {
-                Text("Pick Image")
+                Icon(
+                    imageVector = Icons.Default.Image,
+                    contentDescription = "Pick Image",
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "Pick Image",
+                    style = MaterialTheme.typography.bodyMedium
+                )
             }
 
-            // Show preview if image selected
-            AsyncImage(
-                model = photoPath,
-                contentDescription = "Selected image",
+            Box(
                 modifier = Modifier
-                    .size(120.dp)
-                    .clip(RoundedCornerShape(16.dp))
-            )
+                    .size(64.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .clickable { launcher.launch("image/*") }, contentAlignment = Alignment.Center
+            ) {
+                if (photoPath.isNotBlank()) {
+                    AsyncImage(
+                        model = photoPath,
+                        contentDescription = "Selected image",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .size(64.dp)
+                            .clip(CircleShape)
+                    )
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .size(48.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.surfaceVariant),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Image,
+                            contentDescription = "Placeholder image",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
 
             // Ready switch
             Card(

--- a/app/src/main/java/com/example/conquest/screens/NewCosplayElementScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/NewCosplayElementScreen.kt
@@ -1,5 +1,8 @@
 package com.example.conquest.screens
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -11,6 +14,8 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
@@ -18,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import coil.compose.AsyncImage
 import com.example.conquest.CosplayViewModel
 import com.example.conquest.data.entity.CosplayElement
 import kotlinx.coroutines.launch
@@ -34,12 +40,30 @@ fun NewCosplayElementScreen(
     val cosplayViewModel: CosplayViewModel = viewModel()
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
 
     var name by remember { mutableStateOf("") }
     var cost by remember { mutableStateOf("") }
     var ready by remember { mutableStateOf(false) }
     var highlight by remember { mutableStateOf(false) }
     var bought by remember { mutableStateOf(false) }
+    var photoPath by remember { mutableStateOf("") }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        uri?.let {
+            try {
+                val fileName = "cosplay_element_${System.currentTimeMillis()}.jpg"
+                val savedPath = copyUriToInternalStorage(context, it, fileName)
+                photoPath = savedPath
+            } catch (e: Exception) {
+                coroutineScope.launch {
+                    snackbarHostState.showSnackbar("Failed to save image: ${e.localizedMessage}")
+                }
+            }
+        }
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -82,6 +106,23 @@ fun NewCosplayElementScreen(
                 shape = RoundedCornerShape(32.dp)
             )
 
+            // Image picker button
+            Button(
+                onClick = { launcher.launch("image/*") }, shape = RoundedCornerShape(32.dp)
+            ) {
+                Text("Pick Image")
+            }
+
+            // Show preview if image selected
+            AsyncImage(
+                model = photoPath,
+                contentDescription = "Selected image",
+                modifier = Modifier
+                    .size(120.dp)
+                    .clip(RoundedCornerShape(16.dp))
+            )
+
+            // Ready switch
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -114,6 +155,7 @@ fun NewCosplayElementScreen(
                 }
             }
 
+            // Bought switch
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -174,7 +216,7 @@ fun NewCosplayElementScreen(
                             name = name.trim(),
                             cost = cost.takeIf { it.isNotBlank() }?.toDoubleOrNull(),
                             ready = ready,
-                            photoPath = null,
+                            photoPath = photoPath, // ✅ store image path
                             highlight = highlight,
                             bought = bought,
                             notes = null

--- a/app/src/main/java/com/example/conquest/screens/NewCosplayScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/NewCosplayScreen.kt
@@ -11,6 +11,9 @@ import kotlinx.serialization.Serializable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -60,7 +63,7 @@ fun NewCosplayScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = "New Cosplay Project",
+                text = "New Project",
                 style = MaterialTheme.typography.headlineMedium.copy(
                     fontWeight = FontWeight.Bold, letterSpacing = 1.5.sp
                 ),
@@ -146,25 +149,27 @@ fun NewCosplayScreen(
             )
 
         }
-        Row(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(bottom = 70.dp, start = 16.dp, end = 16.dp)
-                .fillMaxWidth(0.9f),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            OutlinedButton(
-                onClick = { navController.popBackStack() },
-                modifier = Modifier
-                    .weight(1f)
-                    .height(40.dp)
-            ) {
-                Text(
-                    "Cancel", fontSize = 18.sp
-                )
-            }
 
-            Button(
+        IconButton(
+            onClick = { navController.popBackStack() },
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(top = 16.dp, end = 16.dp)
+                .statusBarsPadding()
+                .size(60.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Cancel,
+                contentDescription = "Cancel",
+                tint = MaterialTheme.colorScheme.onBackground
+            )
+        }
+
+        Box(
+            modifier = Modifier.align(Alignment.BottomCenter)
+        ) {
+
+            FloatingActionButton(
                 onClick = {
                     if (characterName.isNotBlank() && series.isNotBlank() && initialDate != null) {
                         val newCosplay = Cosplay(
@@ -187,17 +192,15 @@ fun NewCosplayScreen(
                         }
                     }
                 },
+                containerColor = MaterialTheme.colorScheme.secondary,
+                contentColor = MaterialTheme.colorScheme.primary,
+                shape = RoundedCornerShape(50),
                 modifier = Modifier
-                    .weight(1f)
-                    .height(40.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.secondary,
-                    contentColor = MaterialTheme.colorScheme.primary
-                )
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 16.dp)
+                    .navigationBarsPadding()
             ) {
-                Text(
-                    "Save", fontSize = 18.sp
-                )
+                Icon(Icons.Default.Add, contentDescription = "Save")
             }
         }
         SnackbarHost(

--- a/app/src/main/java/com/example/conquest/screens/NewCosplayTaskScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/NewCosplayTaskScreen.kt
@@ -1,0 +1,193 @@
+package com.example.conquest.screens
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.conquest.CosplayViewModel
+import com.example.conquest.data.entity.CosplayTask
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NewCosplayTaskScreen(val cosplayId: Int)
+
+@Composable
+fun NewCosplayTaskScreen(
+    cosplayId: Int,
+    navController: NavController,
+) {
+    val cosplayViewModel: CosplayViewModel = viewModel()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+
+    var name by remember { mutableStateOf("") }
+    var done by remember { mutableStateOf(false) }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth(0.9f)
+                .padding(top = 70.dp, start = 16.dp, end = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Add Task",
+                style = MaterialTheme.typography.headlineMedium.copy(
+                    fontWeight = FontWeight.Bold, letterSpacing = 1.5.sp
+                ),
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .padding(bottom = 8.dp, top = 8.dp)
+                    .fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
+
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Task Name*") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                shape = RoundedCornerShape(32.dp)
+            )
+
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.outline,
+                        shape = RoundedCornerShape(32.dp)
+                    ),
+                shape = RoundedCornerShape(32.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 18.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(text = "Done")
+                    Switch(
+                        checked = done,
+                        onCheckedChange = { done = it },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = MaterialTheme.colorScheme.primary,
+                            checkedTrackColor = MaterialTheme.colorScheme.secondary,
+                            uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            uncheckedTrackColor = MaterialTheme.colorScheme.secondary
+                        )
+                    )
+                }
+            }
+        }
+
+        IconButton(
+            onClick = { navController.popBackStack() },
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(top = 16.dp, end = 16.dp)
+                .statusBarsPadding()
+                .size(60.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Cancel,
+                contentDescription = "Cancel",
+                tint = MaterialTheme.colorScheme.onBackground
+            )
+        }
+
+        Box(
+            modifier = Modifier.align(Alignment.BottomCenter)
+        ) {
+            FloatingActionButton(
+                onClick = {
+                    if (name.isNotBlank()) {
+                        val task = CosplayTask(
+                            id = 0,
+                            cosplayId = cosplayId,
+                            done = done,
+                            taskName = name.trim(),
+                            alarm = false,
+                            notes = null
+                        )
+                        cosplayViewModel.insertTask(task)
+                        navController.popBackStack()
+                    } else {
+                        coroutineScope.launch {
+                            snackbarHostState.showSnackbar(
+                                message = "Please fill out all required fields!"
+                            )
+                        }
+                    }
+                },
+                containerColor = MaterialTheme.colorScheme.secondary,
+                contentColor = MaterialTheme.colorScheme.primary,
+                shape = RoundedCornerShape(50),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 16.dp)
+                    .navigationBarsPadding()
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Save")
+            }
+        }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 16.dp, vertical = 140.dp),
+            snackbar = { data ->
+                Snackbar(
+                    snackbarData = data,
+                    containerColor = MaterialTheme.colorScheme.tertiary,
+                    contentColor = MaterialTheme.colorScheme.primary,
+                    shape = RoundedCornerShape(32.dp),
+                )
+            })
+    }
+}

--- a/app/src/main/java/com/example/conquest/screens/NewCosplayTaskScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/NewCosplayTaskScreen.kt
@@ -126,7 +126,11 @@ fun NewCosplayTaskScreen(
         }
 
         IconButton(
-            onClick = { navController.popBackStack() },
+            onClick = {
+                navController.navigate(MainCosplayScreen(uid = cosplayId, initialTab = 1)) {
+                    popUpTo(MainCosplayScreen(uid = cosplayId)) { inclusive = true }
+                }
+            },
             modifier = Modifier
                 .align(Alignment.TopEnd)
                 .padding(top = 16.dp, end = 16.dp)
@@ -155,7 +159,9 @@ fun NewCosplayTaskScreen(
                             notes = null
                         )
                         cosplayViewModel.insertTask(task)
-                        navController.popBackStack()
+                        navController.navigate(MainCosplayScreen(uid = cosplayId, initialTab = 1)) {
+                            popUpTo(MainCosplayScreen(uid = cosplayId)) { inclusive = true }
+                        }
                     } else {
                         coroutineScope.launch {
                             snackbarHostState.showSnackbar(

--- a/app/src/main/java/com/example/conquest/screens/ReferenceImagesTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/ReferenceImagesTab.kt
@@ -1,0 +1,126 @@
+package com.example.conquest.screens
+
+import android.content.Context
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.toRoute
+import coil.compose.AsyncImage
+import com.example.conquest.CosplayViewModel
+import com.example.conquest.components.MyFab
+import com.example.conquest.data.entity.CosplayPhoto
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+
+@Composable
+fun ReferenceImagesTab(navBackStackEntry: NavBackStackEntry) {
+    val args = navBackStackEntry.toRoute<MainCosplayScreen>()
+    val context = LocalContext.current
+    val cosplayViewModel: CosplayViewModel = viewModel()
+
+    LaunchedEffect(args.uid) {
+        cosplayViewModel.setCosplayId(args.uid)
+    }
+
+    val photos by cosplayViewModel.photos.collectAsState()
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+    ) {
+
+        PickAndSaveImage(context, Modifier.align(Alignment.BottomCenter)) { savedPath ->
+            cosplayViewModel.addPhoto(args.uid, savedPath)
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text("All Photos:")
+        CosplayPhotoList(photos)
+    }
+}
+
+@Composable
+fun PickAndSaveImage(
+    context: Context, modifier: Modifier, onImageSaved: (String) -> Unit,
+) {
+    var error by remember { mutableStateOf<String?>("") }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        if (uri != null) {
+            try {
+                val fileName = "cosplay_photo_${System.currentTimeMillis()}.jpg"
+                val savedPath = copyUriToInternalStorage(context, uri, fileName)
+                onImageSaved(savedPath)
+            } catch (e: Exception) {
+                error = "Failed to save image: ${e.localizedMessage}"
+            }
+        }
+    }
+
+    MyFab(
+        onClick = { launcher.launch("image/*") }, modifier = modifier
+    )
+
+    error?.let {
+        Text(it, color = MaterialTheme.colorScheme.error)
+    }
+}
+
+fun copyUriToInternalStorage(context: Context, uri: Uri, fileName: String): String {
+    val inputStream: InputStream? = context.contentResolver.openInputStream(uri)
+    val file = File(context.filesDir, fileName)
+    val outputStream: OutputStream = file.outputStream()
+
+    inputStream?.use { input ->
+        outputStream.use { output ->
+            input.copyTo(output)
+        }
+    }
+    return file.absolutePath
+}
+
+@Composable
+fun CosplayPhotoList(photos: List<CosplayPhoto>) {
+    if (photos.isEmpty()) {
+        Text("No photos yet.")
+    } else {
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(photos) { photo ->
+                AsyncImage(
+                    model = photo.path,
+                    contentDescription = "Cosplay photo",
+                    modifier = Modifier.size(120.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/conquest/screens/ReferenceImagesTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/ReferenceImagesTab.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -85,7 +87,11 @@ fun PickAndSaveImage(
     }
 
     MyFab(
-        onClick = { launcher.launch("image/*") }, modifier = modifier
+        onClick = { launcher.launch("image/*") }, modifier = modifier,
+        containerColor = MaterialTheme.colorScheme.tertiary,
+        contentColor = MaterialTheme.colorScheme.primary,
+        icon = Icons.Default.Add,
+        contentDescription = "Add"
     )
 
     error?.let {

--- a/app/src/main/java/com/example/conquest/screens/ReferenceImagesTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/ReferenceImagesTab.kt
@@ -1,7 +1,9 @@
 package com.example.conquest.screens
 
+import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
+import android.webkit.MimeTypeMap
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -66,18 +68,26 @@ fun ReferenceImagesTab(navBackStackEntry: NavBackStackEntry) {
     }
 }
 
+fun getFileExtension(context: Context, uri: Uri): String? {
+    val contentResolver: ContentResolver = context.contentResolver
+    val mimeTypeMap = MimeTypeMap.getSingleton()
+    val mimeType = contentResolver.getType(uri)
+    return mimeTypeMap.getExtensionFromMimeType(mimeType)
+}
+
 @Composable
 fun PickAndSaveImage(
     context: Context, modifier: Modifier, onImageSaved: (String) -> Unit,
 ) {
-    var error by remember { mutableStateOf<String?>("") }
+    var error by remember { mutableStateOf<String?>(null) }
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri: Uri? ->
         if (uri != null) {
             try {
-                val fileName = "cosplay_photo_${System.currentTimeMillis()}.jpg"
+                val extension = getFileExtension(context, uri) ?: "jpg"
+                val fileName = "cosplay_photo_${System.currentTimeMillis()}.$extension"
                 val savedPath = copyUriToInternalStorage(context, uri, fileName)
                 onImageSaved(savedPath)
             } catch (e: Exception) {
@@ -87,7 +97,8 @@ fun PickAndSaveImage(
     }
 
     MyFab(
-        onClick = { launcher.launch("image/*") }, modifier = modifier,
+        onClick = { launcher.launch("image/*") },
+        modifier = modifier,
         containerColor = MaterialTheme.colorScheme.tertiary,
         contentColor = MaterialTheme.colorScheme.primary,
         icon = Icons.Default.Add,

--- a/app/src/main/java/com/example/conquest/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/SettingsScreen.kt
@@ -52,8 +52,7 @@ fun SettingsScreen() {
             .padding(top = 32.dp)
             .background(MaterialTheme.colorScheme.background),
 
-        verticalArrangement = Arrangement.Top,
-        horizontalAlignment = Alignment.CenterHorizontally
+        verticalArrangement = Arrangement.Top, horizontalAlignment = Alignment.CenterHorizontally
     ) {
         ExposedDropdownMenuBox(
             expanded = expanded, onExpandedChange = { expanded = !expanded }) {

--- a/app/src/main/java/com/example/conquest/screens/TasksTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/TasksTab.kt
@@ -6,10 +6,15 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.example.conquest.components.MyFab
 
 @Composable
 fun TasksTab() {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Text("Tasks Content")
+        MyFab(
+            onClick = {},
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
     }
 }

--- a/app/src/main/java/com/example/conquest/screens/TasksTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/TasksTab.kt
@@ -1,0 +1,15 @@
+package com.example.conquest.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun TasksTab() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("Tasks Content")
+    }
+}

--- a/app/src/main/java/com/example/conquest/screens/TasksTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/TasksTab.kt
@@ -2,6 +2,9 @@ package com.example.conquest.screens
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -14,7 +17,11 @@ fun TasksTab() {
         Text("Tasks Content")
         MyFab(
             onClick = {},
-            modifier = Modifier.align(Alignment.BottomCenter)
+            modifier = Modifier.align(Alignment.BottomCenter),
+            containerColor = MaterialTheme.colorScheme.tertiary,
+            contentColor = MaterialTheme.colorScheme.primary,
+            icon = Icons.Default.Add,
+            contentDescription = "Add"
         )
     }
 }

--- a/app/src/main/java/com/example/conquest/screens/TasksTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/TasksTab.kt
@@ -1,22 +1,132 @@
 package com.example.conquest.screens
 
+import androidx.compose.foundation.border
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
+import androidx.navigation.toRoute
+import com.example.conquest.CosplayViewModel
 import com.example.conquest.components.MyFab
 
 @Composable
-fun TasksTab() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Tasks Content")
+fun CosplayTasksTab(navController: NavController, navBackStackEntry: NavBackStackEntry) {
+    val mainArgs = navBackStackEntry.toRoute<MainCosplayScreen>()
+    val cosplayId = mainArgs.uid
+
+    val cosplayViewModel: CosplayViewModel = viewModel()
+
+    LaunchedEffect(cosplayId) {
+        cosplayViewModel.setTaskCosplayId(cosplayId)
+    }
+
+    val tasks by cosplayViewModel.tasks.collectAsState()
+
+    var selectionMode by remember { mutableStateOf(false) }
+    var selectedIds by remember { mutableStateOf(setOf<Int>()) }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        if (selectionMode) {
+            MyFab(
+                onClick = {
+                    cosplayViewModel.deleteTasksByIds(selectedIds)
+                    selectionMode = false
+                    selectedIds = emptySet()
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .zIndex(2f),
+                containerColor = MaterialTheme.colorScheme.secondary,
+                contentColor = MaterialTheme.colorScheme.primary,
+                icon = Icons.Default.Close,
+                contentDescription = "Delete",
+            )
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(18.dp)
+        ) {
+            items(tasks) { task ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(32.dp))
+                        .border(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outline,
+                            shape = RoundedCornerShape(32.dp)
+                        )
+                        .combinedClickable(onClick = {
+                            if (selectionMode) {
+                                val id = task.id
+                                selectedIds =
+                                    if (selectedIds.contains(id)) selectedIds - id else selectedIds + id
+                                if (selectedIds.isEmpty()) selectionMode = false
+                            }
+                        }, onLongClick = {
+                            selectionMode = true
+                            selectedIds = selectedIds + task.id
+                        }),
+                    colors = CardDefaults.cardColors(
+                        containerColor = if (selectedIds.contains(task.id)) MaterialTheme.colorScheme.secondaryContainer
+                        else MaterialTheme.colorScheme.background
+                    ),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+                    shape = RoundedCornerShape(32.dp)
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp)
+                    ) {
+                        Text(
+                            text = task.taskName,
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        if (task.done) {
+                            Text(
+                                text = "Done",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.secondary
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
         MyFab(
-            onClick = {},
+            onClick = { navController.navigate(NewCosplayTaskScreen(cosplayId)) },
             modifier = Modifier.align(Alignment.BottomCenter),
             containerColor = MaterialTheme.colorScheme.tertiary,
             contentColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/example/conquest/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/conquest/ui/theme/Theme.kt
@@ -64,14 +64,13 @@ fun ConQuestTheme(
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
+
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
     }
     val typographyScheme = if (darkTheme) TypographyDark else TypographyWhite
 
     MaterialTheme(
-        colorScheme = colorScheme,
-        typography = typographyScheme,
-        content = content
+        colorScheme = colorScheme, typography = typographyScheme, content = content
     )
 }

--- a/app/src/main/java/com/example/conquest/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/conquest/ui/theme/Type.kt
@@ -15,8 +15,7 @@ val TypographyDark = Typography(
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp,
         color = OffWhite
-    )
-    /* Other default text styles to override
+    )/* Other default text styles to override
     titleLarge = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,

--- a/app/src/main/java/com/example/conquest/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/conquest/ui/theme/Type.kt
@@ -15,7 +15,7 @@ val TypographyDark = Typography(
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp,
         color = OffWhite
-    )/* Other default text styles to override
+    ) /* Other default text styles to override
     titleLarge = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,21 +7,22 @@ coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-kotlinxCoroutinesAndroid = "1.7.3"
-lifecycleRuntimeKtx = "2.9.1"
+kotlinxCoroutinesAndroid = "1.8.1"
+lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
-composeBom = "2025.06.00"
+composeBom = "2025.07.00"
 materialIconsExtended = "1.7.8"
-navigationCompose = "2.9.0"
-roomCompiler = "2.5.0"
-roomRuntime = "2.7.1"
-composeNavigation = "2.9.0"
-serialization = "1.6.3"
+navigationCompose = "2.9.2"
+roomCompiler = "2.7.2"
+roomRuntime = "2.7.2"
+composeNavigation = "2.9.2"
+serialization = "1.7.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
+#noinspection SimilarGradleDependency
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-room-compiler-v250 = { module = "androidx.room:room-compiler", version.ref = "roomCompiler" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }
@@ -41,6 +42,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
+#noinspection SimilarGradleDependency
 navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "composeNavigation" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization"}
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ kotlinxCoroutinesAndroid = "1.7.3"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
 composeBom = "2025.06.00"
+materialIconsExtended = "1.7.8"
 navigationCompose = "2.9.0"
 roomCompiler = "2.5.0"
 roomRuntime = "2.7.1"
@@ -20,6 +21,7 @@ serialization = "1.6.3"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
+androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-room-compiler-v250 = { module = "androidx.room:room-compiler", version.ref = "roomCompiler" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.10.1"
+coilCompose = "2.4.0"
 datastorePreferences = "1.1.7"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
@@ -23,6 +24,7 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 androidx-room-compiler-v250 = { module = "androidx.room:room-compiler", version.ref = "roomCompiler" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,8 +22,6 @@ serialization = "1.7.3"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
-#noinspection SimilarGradleDependency
-androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-room-compiler-v250 = { module = "androidx.room:room-compiler", version.ref = "roomCompiler" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
@@ -42,7 +40,6 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
-#noinspection SimilarGradleDependency
 navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "composeNavigation" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization"}
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the application's data model and UI, focusing on supporting photos, elements, and tasks for cosplays, as well as improving navigation and user experience. The changes include new DAOs and entities, expanded ViewModel functionality, and updates to navigation and UI components to support these new features.

### Data Model and Persistence Enhancements

* Added new DAOs: `CosplayPhotoDao`, `CosplayElementDao`, and `CosplayTaskDao` to manage photos, elements, and tasks associated with cosplays, including insert, delete, and query operations. (`[[1]](diffhunk://#diff-1cd9b7620f4941a308b9b211a5d47d74b9e2fd8677b75648d1b0af12a6932c77R1-R23)`, `[[2]](diffhunk://#diff-c77a3a055e556d1906e3d79ba86bbe4af39344c9cc2acb9e5e7f2939195e9b45R1-R26)`, `[[3]](diffhunk://#diff-789097b40a337de0bd3358ba4e92eff692321615cdca307209c869a1eb89d158R1-R19)`)
* Updated `CosplayDatabase` to include new entities (`CosplayPhoto`, `CosplayElement`, `CosplayTask`) and corresponding DAOs, and increased the database version to 5. (`[app/src/main/java/com/example/conquest/data/database/CosplayDatabase.ktR7-R25](diffhunk://#diff-72e6e957535b88ae808638cebb2115d0d80f46cb6b0b0701f6c8d92c61b0e99aR7-R25)`)
* Modified `CosplayDao` to support bulk deletion of cosplays by IDs instead of single deletes. (`[app/src/main/java/com/example/conquest/data/dao/CosplayDao.ktL15-R15](diffhunk://#diff-3cef5d7135e2b418f06f0b819ddb70213959a265cf55215bebf9d399594423eeL15-R15)`)

### ViewModel Expansion

* Extended `CosplayViewModel` to manage photos, elements, and tasks for cosplays, including methods for CRUD operations and state flows for reactive UI updates. Also added logic to delete associated photo files from disk. (`[app/src/main/java/com/example/conquest/CosplayViewModel.ktR9-R126](diffhunk://#diff-8716dca0473b19b63684dd7b65da00a253aadc2324853e917a7112199d879f87R9-R126)`)

### Navigation and UI Improvements

* Updated navigation in `Navigation.kt` to support new screens for creating and editing cosplay elements and tasks, using route arguments for passing IDs. (`[[1]](diffhunk://#diff-848603d07e971c3604d6fb6efc8edc8bf7a1a4718b41d98505cc6a1e527e5398R1-R15)`, `[[2]](diffhunk://#diff-848603d07e971c3604d6fb6efc8edc8bf7a1a4718b41d98505cc6a1e527e5398L27-R47)`)
* Modified `Drawer.kt` to exclude new element/task creation screens from the drawer, and improved top bar logic for the settings screen. (`[[1]](diffhunk://#diff-648ba25092d3dd6377a909edf8df0ba49ed0d89b3182c768d5a61ecde669f4b6L60-R59)`, `[[2]](diffhunk://#diff-648ba25092d3dd6377a909edf8df0ba49ed0d89b3182c768d5a61ecde669f4b6R125-R152)`)
* Added a reusable floating action button component `MyFab` for consistent UI interactions. (`[app/src/main/java/com/example/conquest/components/MyFloatingActionButton.ktR1-R34](diffhunk://#diff-014ccc6309a9c7f4211c72dea6ad31bd0ab00059b8da597b0251e7dd3b26bed2R1-R34)`)
* Improved the `SearchBar` UI for better usability and appearance. (`[app/src/main/java/com/example/conquest/components/SearchBar.ktL18-R25](diffhunk://#diff-31f713d76f93cb4609f49cbf904539ba642d271eaf27486a490622c57be88faeL18-R25)`)

### Dependency Updates

* Added `coil.compose` and `androidx.material.icons.extended` libraries to support image loading and extended icon sets in the UI. (`[app/build.gradle.ktsR60-R61](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R60-R61)`)