### PR TITLE
15 uibe reference images tab

### DIFF
--- a/app/src/main/java/com/example/conquest/CosplayViewModel.kt
+++ b/app/src/main/java/com/example/conquest/CosplayViewModel.kt
@@ -66,6 +66,17 @@ class CosplayViewModel(application: Application) : AndroidViewModel(application)
         }
     }
 
+    // New: reactive getter for a single photo
+    fun getPhotoById(id: Int): Flow<CosplayPhoto?> = photoDao.getPhotoById(id)
+
+    // New: update a photo and optionally delete the old file if path changed
+    fun updatePhoto(updated: CosplayPhoto, oldPathToDelete: String? = null) {
+        viewModelScope.launch {
+            photoDao.updatePhoto(updated)
+            oldPathToDelete?.let { deleteFileByPath(it) }
+        }
+    }
+
     fun insertElement(element: CosplayElement) {
         viewModelScope.launch {
             elementDao.insertElement(element)

--- a/app/src/main/java/com/example/conquest/CosplayViewModel.kt
+++ b/app/src/main/java/com/example/conquest/CosplayViewModel.kt
@@ -58,6 +58,14 @@ class CosplayViewModel(application: Application) : AndroidViewModel(application)
         }
     }
 
+    fun deletePhotosByIds(ids: Set<Int>) {
+        viewModelScope.launch {
+            val toDelete = photoDao.getPhotosByIdsOnce(ids)
+            photoDao.deletePhotosByIds(ids)
+            toDelete.forEach { deleteFileByPath(it.path) }
+        }
+    }
+
     fun insertElement(element: CosplayElement) {
         viewModelScope.launch {
             elementDao.insertElement(element)

--- a/app/src/main/java/com/example/conquest/components/Navigation.kt
+++ b/app/src/main/java/com/example/conquest/components/Navigation.kt
@@ -14,6 +14,7 @@ import com.example.conquest.screens.NewCosplayTaskScreen
 import com.example.conquest.screens.SettingsScreenParams
 import com.example.conquest.screens.EditCosplayElementScreen
 import com.example.conquest.screens.EditTaskScreen
+import com.example.conquest.screens.EditReferenceImageScreen
 
 @Composable
 fun MainNavigation(navController: NavHostController, searchQuery: String) {
@@ -51,6 +52,12 @@ fun MainNavigation(navController: NavHostController, searchQuery: String) {
             val args = backStackEntry.toRoute<EditTaskScreen>()
             EditTaskScreen(
                 taskId = args.taskId, navController = navController
+            )
+        }
+        composable<EditReferenceImageScreen> { backStackEntry ->
+            val args = backStackEntry.toRoute<EditReferenceImageScreen>()
+            EditReferenceImageScreen(
+                photoId = args.photoId, navController = navController
             )
         }
     }

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayPhotoDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayPhotoDao.kt
@@ -20,4 +20,10 @@ interface CosplayPhotoDao {
 
     @Query("SELECT * FROM cosplay_photos WHERE cosplay_id = :cosplayId")
     fun getPhotosForCosplay(cosplayId: Int): Flow<List<CosplayPhoto>>
+
+    @Query("SELECT * FROM cosplay_photos WHERE id IN (:ids)")
+    suspend fun getPhotosByIdsOnce(ids: Set<Int>): List<CosplayPhoto>
+
+    @Query("DELETE FROM cosplay_photos WHERE id IN (:ids)")
+    suspend fun deletePhotosByIds(ids: Set<Int>)
 }

--- a/app/src/main/java/com/example/conquest/data/dao/CosplayPhotoDao.kt
+++ b/app/src/main/java/com/example/conquest/data/dao/CosplayPhotoDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Update
 import com.example.conquest.data.entity.CosplayPhoto
 import kotlinx.coroutines.flow.Flow
 
@@ -26,4 +27,10 @@ interface CosplayPhotoDao {
 
     @Query("DELETE FROM cosplay_photos WHERE id IN (:ids)")
     suspend fun deletePhotosByIds(ids: Set<Int>)
+
+    @Query("SELECT * FROM cosplay_photos WHERE id = :id LIMIT 1")
+    fun getPhotoById(id: Int): Flow<CosplayPhoto?>
+
+    @Update
+    suspend fun updatePhoto(photo: CosplayPhoto)
 }

--- a/app/src/main/java/com/example/conquest/data/database/CosplayDatabase.kt
+++ b/app/src/main/java/com/example/conquest/data/database/CosplayDatabase.kt
@@ -15,7 +15,7 @@ import com.example.conquest.data.entity.CosplayTask
 
 @Database(
     entities = [Cosplay::class, CosplayPhoto::class, CosplayElement::class, CosplayTask::class],
-    version = 6
+    version = 7
 )
 @TypeConverters(DateConverter::class)
 abstract class CosplayDatabase : RoomDatabase() {

--- a/app/src/main/java/com/example/conquest/data/entity/CosplayPhotos.kt
+++ b/app/src/main/java/com/example/conquest/data/entity/CosplayPhotos.kt
@@ -17,5 +17,6 @@ import androidx.room.PrimaryKey
 data class CosplayPhoto(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
     @ColumnInfo(name = "cosplay_id") val cosplayId: Int,
-    @ColumnInfo(name = "path") val path: String
+    @ColumnInfo(name = "path") val path: String,
+    @ColumnInfo(name = "notes") val notes: String? = null
 )

--- a/app/src/main/java/com/example/conquest/screens/EditReferenceImageScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/EditReferenceImageScreen.kt
@@ -1,0 +1,173 @@
+package com.example.conquest.screens
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import coil.compose.AsyncImage
+import com.example.conquest.CosplayViewModel
+import com.example.conquest.components.MyFab
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EditReferenceImageScreen(val photoId: Int)
+
+@Composable
+fun EditReferenceImageScreen(
+    photoId: Int, navController: NavController, cosplayViewModel: CosplayViewModel = viewModel()
+) {
+    val context = LocalContext.current
+    val photo by cosplayViewModel.getPhotoById(photoId).collectAsState(initial = null)
+
+    var photoPath by remember { mutableStateOf("") }
+    var notes by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf("") }
+
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        if (uri != null) {
+            try {
+                val extension = getFileExtension(context, uri) ?: "jpg"
+                val fileName = "cosplay_photo_${System.currentTimeMillis()}.$extension"
+                val savedPath = copyUriToInternalStorage(context, uri, fileName)
+                photoPath = savedPath
+            } catch (e: Exception) {
+                error = "Failed to save image: ${e.localizedMessage}"
+            }
+        }
+    }
+
+    LaunchedEffect(photo) {
+        photo?.let {
+            photoPath = it.path
+            notes = it.notes ?: ""
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp)
+                .padding(top = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = "Reference Image",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+            )
+            Box(
+                modifier = Modifier
+                    .size(120.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .clickable { imagePickerLauncher.launch("image/*") },
+                contentAlignment = Alignment.Center
+            ) {
+                if (photoPath.isNotEmpty()) {
+                    AsyncImage(
+                        model = photoPath,
+                        contentDescription = "Reference image",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clip(RoundedCornerShape(16.dp))
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Default.Image,
+                        contentDescription = "Pick image",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            if (error.isNotEmpty()) {
+                Text(error, color = MaterialTheme.colorScheme.error)
+            }
+
+            Text(
+                text = "Notes",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+            )
+            OutlinedTextField(
+                value = notes,
+                onValueChange = { notes = it },
+                label = { Text("Notes") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(120.dp),
+                shape = RoundedCornerShape(20.dp),
+                maxLines = 6
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            MyFab(
+                onClick = { navController.popBackStack() },
+                containerColor = MaterialTheme.colorScheme.errorContainer,
+                contentColor = MaterialTheme.colorScheme.primary,
+                icon = Icons.Default.Close,
+                contentDescription = "Discard"
+            )
+
+            MyFab(
+                onClick = {
+                    photo?.let { current ->
+                        val oldPath = current.path
+                        val newPath = if (photoPath.isNotEmpty()) photoPath else oldPath
+                        val updated = current.copy(path = newPath, notes = notes.ifBlank { null })
+                        val deleteOld = if (newPath != oldPath) oldPath else null
+                        cosplayViewModel.updatePhoto(updated, oldPathToDelete = deleteOld)
+                    }
+                    navController.popBackStack()
+                },
+                containerColor = MaterialTheme.colorScheme.secondary,
+                contentColor = MaterialTheme.colorScheme.primary,
+                icon = Icons.Default.Check,
+                contentDescription = "Save"
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
+++ b/app/src/main/java/com/example/conquest/screens/MainCosplayScreen.kt
@@ -72,7 +72,7 @@ fun CosplayTabs(
             when (page) {
                 0 -> CosplayElementsTab(navController, navBackStackEntry)
                 1 -> CosplayTasksTab(navController, navBackStackEntry)
-                2 -> ReferenceImagesTab(navBackStackEntry)
+                2 -> ReferenceImagesTab(navBackStackEntry, navController)
             }
         }
     }

--- a/app/src/main/java/com/example/conquest/screens/ReferenceImagesTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/ReferenceImagesTab.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
 import androidx.navigation.toRoute
 import coil.compose.AsyncImage
 import com.example.conquest.CosplayViewModel
@@ -50,7 +51,7 @@ import java.io.InputStream
 import java.io.OutputStream
 
 @Composable
-fun ReferenceImagesTab(navBackStackEntry: NavBackStackEntry) {
+fun ReferenceImagesTab(navBackStackEntry: NavBackStackEntry, navController: NavController) {
     val args = navBackStackEntry.toRoute<MainCosplayScreen>()
     val context = LocalContext.current
     val cosplayViewModel: CosplayViewModel = viewModel()
@@ -90,23 +91,19 @@ fun ReferenceImagesTab(navBackStackEntry: NavBackStackEntry) {
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        CosplayPhotoList(
-            photos = photos,
-            selectedIds = selectedIds,
-            onItemClick = { photo ->
-                if (selectionMode) {
-                    val id = photo.id
-                    val newSet =
-                        if (selectedIds.contains(id)) selectedIds - id else selectedIds + id
-                    selectedIds = newSet
-                    if (newSet.isEmpty()) selectionMode = false
-                }
-            },
-            onItemLongClick = { photo ->
-                selectionMode = true
-                selectedIds = selectedIds + photo.id
+        CosplayPhotoList(photos = photos, selectedIds = selectedIds, onItemClick = { photo ->
+            if (selectionMode) {
+                val id = photo.id
+                val newSet = if (selectedIds.contains(id)) selectedIds - id else selectedIds + id
+                selectedIds = newSet
+                if (newSet.isEmpty()) selectionMode = false
+            } else {
+                navController.navigate(EditReferenceImageScreen(photo.id))
             }
-        )
+        }, onItemLongClick = { photo ->
+            selectionMode = true
+            selectedIds = selectedIds + photo.id
+        })
     }
 }
 
@@ -182,8 +179,7 @@ fun CosplayPhotoList(
         }
     } else {
         LazyRow(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             items(items = photos, key = { it.id }) { photo ->
                 Card(
@@ -197,13 +193,10 @@ fun CosplayPhotoList(
                         )
                         .combinedClickable(
                             onClick = { onItemClick(photo) },
-                            onLongClick = { onItemLongClick(photo) }
-                        ),
+                            onLongClick = { onItemLongClick(photo) }),
                     colors = CardDefaults.cardColors(
-                        containerColor = if (selectedIds.contains(photo.id))
-                            MaterialTheme.colorScheme.secondaryContainer
-                        else
-                            MaterialTheme.colorScheme.background
+                        containerColor = if (selectedIds.contains(photo.id)) MaterialTheme.colorScheme.secondaryContainer
+                        else MaterialTheme.colorScheme.background
                     ),
                     elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
                     shape = RoundedCornerShape(16.dp)

--- a/app/src/main/java/com/example/conquest/screens/ReferenceImagesTab.kt
+++ b/app/src/main/java/com/example/conquest/screens/ReferenceImagesTab.kt
@@ -6,6 +6,8 @@ import android.net.Uri
 import android.webkit.MimeTypeMap
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.border
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
@@ -15,8 +17,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,8 +34,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.toRoute
@@ -53,9 +61,28 @@ fun ReferenceImagesTab(navBackStackEntry: NavBackStackEntry) {
 
     val photos by cosplayViewModel.photos.collectAsState()
 
+    var selectionMode by remember { mutableStateOf(false) }
+    var selectedIds by remember { mutableStateOf(setOf<Int>()) }
+
     Box(
         modifier = Modifier.fillMaxSize(),
     ) {
+        if (selectionMode) {
+            MyFab(
+                onClick = {
+                    cosplayViewModel.deletePhotosByIds(selectedIds)
+                    selectionMode = false
+                    selectedIds = emptySet()
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .zIndex(2f),
+                containerColor = MaterialTheme.colorScheme.secondary,
+                contentColor = MaterialTheme.colorScheme.primary,
+                icon = Icons.Default.Close,
+                contentDescription = "Delete"
+            )
+        }
 
         PickAndSaveImage(context, Modifier.align(Alignment.BottomCenter)) { savedPath ->
             cosplayViewModel.addPhoto(args.uid, savedPath)
@@ -63,8 +90,23 @@ fun ReferenceImagesTab(navBackStackEntry: NavBackStackEntry) {
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        Text("All Photos:")
-        CosplayPhotoList(photos)
+        CosplayPhotoList(
+            photos = photos,
+            selectedIds = selectedIds,
+            onItemClick = { photo ->
+                if (selectionMode) {
+                    val id = photo.id
+                    val newSet =
+                        if (selectedIds.contains(id)) selectedIds - id else selectedIds + id
+                    selectedIds = newSet
+                    if (newSet.isEmpty()) selectionMode = false
+                }
+            },
+            onItemLongClick = { photo ->
+                selectionMode = true
+                selectedIds = selectedIds + photo.id
+            }
+        )
     }
 }
 
@@ -124,19 +166,54 @@ fun copyUriToInternalStorage(context: Context, uri: Uri, fileName: String): Stri
 }
 
 @Composable
-fun CosplayPhotoList(photos: List<CosplayPhoto>) {
+fun CosplayPhotoList(
+    photos: List<CosplayPhoto>,
+    selectedIds: Set<Int>,
+    onItemClick: (CosplayPhoto) -> Unit,
+    onItemLongClick: (CosplayPhoto) -> Unit
+) {
     if (photos.isEmpty()) {
-        Text("No photos yet.")
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp), contentAlignment = Alignment.Center
+        ) {
+            Text("No images added yet.")
+        }
     } else {
         LazyRow(
-            modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            items(photos) { photo ->
-                AsyncImage(
-                    model = photo.path,
-                    contentDescription = "Cosplay photo",
-                    modifier = Modifier.size(120.dp)
-                )
+            items(items = photos, key = { it.id }) { photo ->
+                Card(
+                    modifier = Modifier
+                        .size(120.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .border(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outline,
+                            shape = RoundedCornerShape(16.dp)
+                        )
+                        .combinedClickable(
+                            onClick = { onItemClick(photo) },
+                            onLongClick = { onItemLongClick(photo) }
+                        ),
+                    colors = CardDefaults.cardColors(
+                        containerColor = if (selectedIds.contains(photo.id))
+                            MaterialTheme.colorScheme.secondaryContainer
+                        else
+                            MaterialTheme.colorScheme.background
+                    ),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+                    shape = RoundedCornerShape(16.dp)
+                ) {
+                    AsyncImage(
+                        model = photo.path,
+                        contentDescription = "Cosplay photo",
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
This pull request introduces significant improvements to the handling and editing of cosplay reference images, including enhanced photo management, a new editing screen, and support for photo notes. The changes add multi-select and delete functionality to the reference image tab, allow editing of photo notes and paths, and update the database schema to support these features.

**Photo Management Enhancements**
* Added multi-select and batch delete functionality for reference images in `ReferenceImagesTab`, allowing users to select multiple photos and delete them at once.
* Updated `CosplayViewModel` with new methods for deleting photos by IDs, updating photos (including deleting old files if the path changes), and retrieving a single photo reactively.
* Extended `CosplayPhotoDao` with queries for batch operations and updates, including getting photos by IDs, deleting by IDs, getting a single photo by ID, and updating a photo.

**Reference Image Editing**
* Added a new screen, `EditReferenceImageScreen`, for editing a reference image's path and notes. This screen is integrated into the navigation and can be accessed from the reference images tab. [[1]](diffhunk://#diff-381e483a2a7a32b15f82ce76072e656bcbfddd533363f0a369ad5db0cd675ed3R1-R173) [[2]](diffhunk://#diff-848603d07e971c3604d6fb6efc8edc8bf7a1a4718b41d98505cc6a1e527e5398R17) [[3]](diffhunk://#diff-848603d07e971c3604d6fb6efc8edc8bf7a1a4718b41d98505cc6a1e527e5398R57-R62) [[4]](diffhunk://#diff-aa02aff997a558a82a614cf263e95876ccc0002ed8fa40149fe16971b71eb316L75-R75)

**Database and Data Model Updates**
* Updated the `CosplayPhoto` entity to include a nullable `notes` field, and incremented the database version to 7 to reflect the schema change. [[1]](diffhunk://#diff-0acd1cff80d2434185cf47afc4d4565647c75c14caa2c4575d7bc564f8edfcbeL20-R21) [[2]](diffhunk://#diff-72e6e957535b88ae808638cebb2115d0d80f46cb6b0b0701f6c8d92c61b0e99aL18-R18)

**UI Improvements**
* Improved the UI for displaying reference images, including card styling, selection highlighting, and empty state messaging.

These changes collectively provide a more robust and user-friendly experience for managing cosplay reference images and their associated metadata.